### PR TITLE
Retry  when doing an atomic rename

### DIFF
--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -7,6 +7,7 @@ require 'lhm/table'
 require 'lhm/migration'
 require 'lhm/atomic_switcher'
 
+
 describe Lhm::AtomicSwitcher do
   include IntegrationHelper
 
@@ -17,6 +18,102 @@ describe Lhm::AtomicSwitcher do
       @origin      = table_create("origin")
       @destination = table_create("destination")
       @migration   = Lhm::Migration.new(@origin, @destination, "id")
+      @connection.execute("SET GLOBAL innodb_lock_wait_timeout=3")
+      @connection.execute("SET GLOBAL lock_wait_timeout=3")
+    end
+
+   it "should retry on lock wait timeouts" do
+     begin
+       old_verbose, $VERBOSE = $VERBOSE, nil
+       old_retry_sleep = Lhm::AtomicSwitcher::RETRY_SLEEP_TIME
+       Lhm::AtomicSwitcher::RETRY_SLEEP_TIME = 0.2
+
+       mutex = Mutex.new
+       cond = ConditionVariable.new
+
+       locking_thread = Thread.new do 
+         with_per_thread_lhm_connection do |conn|
+
+           conn.sql('BEGIN')
+           conn.sql("DELETE from #{@destination.name}")
+           mutex.synchronize { sleep(1); cond.signal }
+           sleep(10)
+           conn.sql('ROLLBACK')
+         end
+       end
+
+       switching_thread = Thread.new do
+         with_per_thread_lhm_connection do |conn|
+           switcher = Lhm::AtomicSwitcher.new(@migration, conn)
+           mutex.synchronize do
+             cond.wait(mutex)
+             switcher.run
+           end
+           Thread.current[:retries] = switcher.retries
+         end
+       end
+
+       switching_thread.join
+       assert switching_thread[:retries] > 0, "The switcher did not retry"
+     ensure
+       Lhm::AtomicSwitcher::RETRY_SLEEP_TIME = old_retry_sleep
+       $VERBOSE = old_verbose
+     end
+   end
+
+   it "should give up on lock wait timeouts after MAX_RETRIES" do
+     begin
+       old_verbose, $VERBOSE = $VERBOSE, nil
+
+       old_retry_sleep = Lhm::AtomicSwitcher::RETRY_SLEEP_TIME
+       old_max_retries = Lhm::AtomicSwitcher::MAX_RETRIES
+       Lhm::AtomicSwitcher::RETRY_SLEEP_TIME = 0
+       Lhm::AtomicSwitcher::MAX_RETRIES = 2
+
+       mutex = Mutex.new
+       cond = ConditionVariable.new
+
+       locking_thread = Thread.new do 
+         with_per_thread_lhm_connection do |conn|
+
+           conn.sql('BEGIN')
+           conn.sql("DELETE from #{@destination.name}")
+           mutex.synchronize { sleep(1); cond.signal }
+           sleep(100)
+           conn.sql('ROLLBACK')
+         end
+       end
+
+       switching_thread = Thread.new do
+         with_per_thread_lhm_connection do |conn|
+           switcher = Lhm::AtomicSwitcher.new(@migration, conn)
+           mutex.synchronize do
+             cond.wait(mutex)
+             begin
+               switcher.run
+             rescue ActiveRecord::StatementInvalid => error
+               Thread.current[:exception] = error
+
+             end
+           end
+         end
+       end
+
+       switching_thread.join
+       assert switching_thread[:exception].is_a?(ActiveRecord::StatementInvalid)
+     ensure
+       Lhm::AtomicSwitcher::RETRY_SLEEP_TIME = old_retry_sleep
+       Lhm::AtomicSwitcher::MAX_RETRIES = old_max_retries
+       $VERBOSE = old_verbose
+     end
+   end
+
+    it "should raise on non lock wait timeout exceptions" do
+      switcher = Lhm::AtomicSwitcher.new(@migration, connection)
+      switcher.send :define_singleton_method, :statements do 
+        ['SELECT', '*', 'FROM', 'nonexistent']
+      end
+      ->{ switcher.run }.must_raise(ActiveRecord::StatementInvalid)
     end
 
     it "rename origin to archive" do

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -154,6 +154,14 @@ module IntegrationHelper
     >)
   end
 
+  def with_per_thread_lhm_connection
+    pool = ActiveRecord::Base.establish_connection(adapter: 'mysql2', database: 'lhm')
+    pool.with_connection do |conn|
+      lhm_connection = Lhm::Connection.new(conn)
+      yield  lhm_connection
+    end
+  end
+
   #
   # Environment
   #

--- a/spec/unit/printer_spec.rb
+++ b/spec/unit/printer_spec.rb
@@ -14,7 +14,7 @@ describe Lhm::Printer do
     it "prints the percentage" do
       mock = MiniTest::Mock.new
       10.times do |i|
-        mock.expect(:write, :return_value) do |message|
+        mock.expect(:write, :return_value, [String]) do |message|
           assert_match /^\r/, message.first
           assert_match /#{i}\/10/, message.first
         end
@@ -29,7 +29,7 @@ describe Lhm::Printer do
       @length = 0
       mock = MiniTest::Mock.new
       3.times do |i|
-        mock.expect(:write, :return_value) do |message|
+        mock.expect(:write, :return_value, [String]) do |message|
           assert message.first.length >= @length
           @length = message.first.length
         end


### PR DESCRIPTION
## Problem

If the metadata lock is taken a LHM will fail with   lock wait timeout,
## Solution

Sleep one second and retry until we succeed

@arthurnn  @sroysen 

~~Should we have a max number of retries?~~ 
Yes and done.

Should the wait be more than 1 sec?
