### PR TITLE
Raise an error when index name is invalid

### DIFF
--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -196,6 +196,7 @@ module Lhm
     end
 
     def index_ddl(cols, unique = nil, index_name = nil)
+      assert_valid_idx_name(index_name)
       type = unique ? "unique index" : "index"
       index_name ||= idx_name(@origin.name, cols)
       parts = [type, index_name, @name, idx_spec(cols)]
@@ -204,6 +205,12 @@ module Lhm
 
     def order_column
       @options[:order_column] || @origin.pk
+    end
+
+    def assert_valid_idx_name(index_name)
+      if index_name && !(index_name.is_a?(String) || index_name.is_a?(Symbol))
+        raise ArgumentError, "index_name must be a string or symbol"
+      end
     end
   end
 end

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -47,6 +47,12 @@ describe Lhm::Migrator do
       ])
     end
 
+    it "should raise an error when the index name is not a string or symbol" do
+      assert_raises ArgumentError do
+        @creator.add_index([:a, :b], :name => :custom_index_name)
+      end
+    end
+
     it "should add a unique index" do
       @creator.add_unique_index(["a(5)", :b])
 
@@ -61,6 +67,12 @@ describe Lhm::Migrator do
       @creator.statements.must_equal([
         "create unique index `custom_index_name` on `lhmn_alt` (`a`, `b`)"
       ])
+    end
+
+    it "should raise an error when the unique index name is not a string or symbol" do
+      assert_raises ArgumentError do
+        @creator.add_unique_index([:a, :b], :name => :custom_index_name)
+      end
     end
 
     it "should remove an index" do


### PR DESCRIPTION
Prevents this kind of thing:

```ruby
change_table :foo do |m|
  m.add_index [:bar], name: 'bar'
end
```

```sql
create index `{:name=>"bar"}` on `lhmn_foo` (`bar`)
```

@arthurnn @camilo 
cc @sroysen @SingerWang 