### PR TITLE
Add slave lag throttler and other required updates

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -4,6 +4,7 @@
 require 'lhm/table'
 require 'lhm/invoker'
 require 'lhm/connection'
+require 'lhm/throttler'
 require 'lhm/version'
 require 'logger'
 

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -53,6 +53,13 @@ module Lhm
         end
       end
 
+      if options[:throttler]
+        throttler_options = options[:throttler_options] || {}
+        options[:throttler] = Throttler::Factory.create_throttler(options[:throttler], throttler_options)
+      else
+        options[:throttler] = Lhm.throttler
+      end
+
       set_session_lock_wait_timeouts
 
       migration = @migrator.run

--- a/lib/lhm/throttler.rb
+++ b/lib/lhm/throttler.rb
@@ -1,0 +1,33 @@
+require 'lhm/throttler/time'
+require 'lhm/throttler/slave_lag'
+
+module Lhm
+  module Throttler
+    CLASSES = { :time_throttler => Throttler::Time, :slave_lag_throttler => Throttler::SlaveLag }
+
+    def throttler
+      @throttler ||= Throttler::Time.new
+    end
+
+    def setup_throttler(type, options = {})
+      @throttler = Factory.create_throttler(type, options)
+    end
+
+    class Factory
+      def self.create_throttler(type, options = {})
+        case type
+        when Lhm::Command
+          type
+        when Symbol
+          CLASSES[type].new(options)
+        when String
+          CLASSES[type.to_sym].new(options)
+        when Class
+          type.new(options)
+        else
+          raise ArgumentError, 'type argument must be a Symbol, String or Class'
+        end
+      end
+    end
+  end
+end

--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -1,0 +1,133 @@
+module Lhm
+  module Throttler
+
+    def self.format_hosts(hosts)
+      hosts.map { |host| host.partition(':')[0] }
+        .delete_if { |host| host == 'localhost' || host == '127.0.0.1' }
+    end
+
+    class SlaveLag
+      include Command
+
+      INITIAL_TIMEOUT = 0.1
+      DEFAULT_STRIDE = 40_000
+      DEFAULT_MAX_ALLOWED_LAG = 10
+
+      MAX_TIMEOUT = INITIAL_TIMEOUT * 1024
+
+      attr_accessor :timeout_seconds, :allowed_lag, :stride, :connection
+
+      def initialize(options = {})
+        @timeout_seconds = INITIAL_TIMEOUT
+        @stride = options[:stride] || DEFAULT_STRIDE
+        @allowed_lag = options[:allowed_lag] || DEFAULT_MAX_ALLOWED_LAG
+        @slaves = {}
+        @get_config = options[:current_config]
+      end
+
+      def execute
+        sleep(throttle_seconds)
+      end
+
+      private
+
+      def throttle_seconds
+        lag = max_current_slave_lag
+
+        if lag > @allowed_lag && @timeout_seconds < MAX_TIMEOUT
+          Lhm.logger.info("Increasing timeout between strides from #{@timeout_seconds} to #{@timeout_seconds * 2} because #{lag} seconds of slave lag detected is greater than the maximum of #{@allowed_lag} seconds allowed.")
+          @timeout_seconds = @timeout_seconds * 2
+        elsif lag <= @allowed_lag && @timeout_seconds > INITIAL_TIMEOUT
+          Lhm.logger.info("Decreasing timeout between strides from #{@timeout_seconds} to #{@timeout_seconds / 2} because #{lag} seconds of slave lag detected is less than or equal to the #{@allowed_lag} seconds allowed.")
+          @timeout_seconds = @timeout_seconds / 2
+        else
+          @timeout_seconds
+        end
+      end
+
+      def slaves
+        @slaves[@connection] ||= get_slaves
+      end
+
+      def get_slaves
+        slaves = []
+        slave_hosts = master_slave_hosts
+        Lhm.logger.info("master_slave_hosts: #{master_slave_hosts}")
+        while slave_hosts.any? do
+          host = slave_hosts.pop
+          Lhm.logger.info("host: #{host}")
+          slave = Slave.new(host, @get_config)
+          if slaves.map(&:host).exclude?(host) && slave.connection
+            Lhm.logger.info("slave.slave_hosts: #{slave.slave_hosts}")
+            slaves << slave
+            slave_hosts << slave.slave_hosts
+            slave_hosts.flatten!
+          end
+        end
+        Lhm.logger.info("!!!!!!!!!!! FINAL SLAVES: #{slaves.map(&:host)}")
+        slaves
+      end
+
+      def master_slave_hosts
+        Throttler.format_hosts(@connection.select_values(Slave::SQL_SELECT_SLAVE_HOSTS))
+      end
+
+      def max_current_slave_lag
+        max = slaves.map { |slave| slave.lag }.flatten.push(0).max
+        Lhm.logger.info "Max current slave lag: #{max}"
+        max
+      end
+    end
+
+    class Slave
+      SQL_SELECT_SLAVE_HOSTS = "SELECT host FROM information_schema.processlist WHERE command='Binlog Dump'"
+      SQL_SELECT_MAX_SLAVE_LAG = 'SHOW SLAVE STATUS'
+
+      attr_reader :host, :connection
+
+      def initialize(host, get_config=nil)
+        @host = host
+        @connection = client(config(get_config))
+      end
+
+      def slave_hosts
+        Throttler.format_hosts(query_connection(SQL_SELECT_SLAVE_HOSTS, 'host'))
+      end
+
+      def lag
+        lag = query_connection(SQL_SELECT_MAX_SLAVE_LAG, 'Seconds_Behind_Master')
+        Lhm.logger.info "CALCULATED LAG #{lag} FOR #{@host}"
+        lag
+      end
+
+      private
+
+      def client(config)
+        begin
+          Mysql2::Client.new(config)
+        rescue Mysql2::Error => e
+          Lhm.logger.info "Error conecting to #{@host}: #{e}"
+          nil
+        end
+      end
+
+      def config(get_config)
+        attrs = get_config ? get_config.call : ActiveRecord::Base.connection_pool.spec.config.dup
+        {
+          :host => @host,
+          :username => attrs['username'],
+          :password => attrs['password'],
+          :database => attrs['database']
+        }
+      end
+
+      def query_connection(query, result)
+        begin
+          @connection.query(query).map { |row| row[result] }
+        rescue Error => e
+          raise Lhm::Error, "Unable to connect and/or query slave to determine slave lag. Migration aborting because of: #{e}"
+        end
+      end
+    end
+  end
+end

--- a/lib/lhm/throttler/time.rb
+++ b/lib/lhm/throttler/time.rb
@@ -1,0 +1,29 @@
+module Lhm
+  module Throttler
+    class Time
+      include Command
+
+      DEFAULT_TIMEOUT = 0.1
+      DEFAULT_STRIDE = 40_000
+
+      attr_accessor :timeout_seconds
+      attr_accessor :stride
+
+      def initialize(options = {})
+        @timeout_seconds = options[:delay] || DEFAULT_TIMEOUT
+        @stride = options[:stride] || DEFAULT_STRIDE
+      end
+
+      def execute
+        sleep timeout_seconds
+      end
+    end
+
+    class LegacyTime < Time
+      def initialize(timeout, stride)
+        @timeout_seconds = timeout / 1000.0
+        @stride = stride
+      end
+    end
+  end
+end

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -2,8 +2,6 @@
 # Schmidt
 
 require File.expand_path(File.dirname(__FILE__)) + '/integration_helper'
-
-require 'lhm'
 require 'lhm/table'
 require 'lhm/migration'
 
@@ -19,20 +17,102 @@ describe Lhm::Chunker do
       @migration = Lhm::Migration.new(@origin, @destination, "id")
     end
 
-    it "should copy 23 rows from origin to destination" do
+    it 'should copy 23 rows from origin to destination with time based throttler' do
       23.times { |n| execute("insert into origin set id = '#{ n * n + 23 }'") }
 
       printer = MiniTest::Mock.new
       5.times { printer.expect(:notify, :return_value, [Fixnum, Fixnum]) }
       printer.expect(:end, :return_value, [])
 
-      Lhm::Chunker.new(@migration, connection, { :stride => 100, :printer => printer }).run
+      Lhm::Chunker.new(
+        @migration, connection, { :throttler => Lhm::Throttler::Time.new(:stride => 100), :printer => printer }
+      ).run
 
       slave do
         count_all(@destination.name).must_equal(23)
       end
 
-     printer.verify
+      printer.verify
+    end
+
+    it 'should copy 23 rows from origin to destination with slave lag based throttler' do
+      23.times { |n| execute("insert into origin set id = '#{ n * n + 23 }'") }
+
+      printer = MiniTest::Mock.new
+      5.times { printer.expect(:notify, :return_value, [Fixnum, Fixnum]) }
+      printer.expect(:end, :return_value, [])
+
+      Lhm::Chunker.new(
+        @migration, connection, { :throttler => Lhm::Throttler::SlaveLag.new(:stride => 100), :printer => printer }
+      ).run
+
+      slave do
+        count_all(@destination.name).must_equal(23)
+      end
+
+      printer.verify
+    end
+
+    it 'should throttle work stride based on slave lag' do
+      5.times { |n| execute("insert into origin set id = '#{ (n * n) + 1 }'") }
+
+      printer = MiniTest::Mock.new
+      15.times { printer.expect(:notify, :return_value, [Fixnum, Fixnum]) }
+      printer.expect(:end, :return_value, [])
+
+      throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0)
+      def throttler.max_current_slave_lag
+        1
+      end
+
+      Lhm::Chunker.new(
+        @migration, connection, { :throttler => throttler, :printer => printer }
+      ).run
+
+      assert_equal(Lhm::Throttler::SlaveLag::INITIAL_TIMEOUT * 2 * 2, throttler.timeout_seconds)
+
+      slave do
+        count_all(@destination.name).must_equal(5)
+      end
+
+      printer.verify
+    end
+
+    it 'should detect a single slave with no lag in the default configuration' do
+      5.times { |n| execute("insert into origin set id = '#{ (n * n) + 1 }'") }
+
+      printer = MiniTest::Mock.new
+      15.times { printer.expect(:notify, :return_value, [Fixnum, Fixnum]) }
+      printer.expect(:end, :return_value, [])
+
+      throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0)
+
+      def throttler.slave_hosts
+        ['127.0.0.1']
+      end
+
+      if master_slave_mode?
+        def throttler.slave_connection(slave)
+          adapter_method = defined?(Mysql2) ? 'mysql2_connection' : 'mysql_connection'
+          config = ActiveRecord::Base.connection_pool.spec.config.dup
+          config[:host] = slave
+          config[:port] = 3307
+          ActiveRecord::Base.send(adapter_method, config)
+        end
+      end
+
+      Lhm::Chunker.new(
+        @migration, connection, { :throttler => throttler, :printer => printer }
+      ).run
+
+      assert_equal(Lhm::Throttler::SlaveLag::INITIAL_TIMEOUT, throttler.timeout_seconds)
+      assert_equal(0, throttler.send(:max_current_slave_lag))
+
+      slave do
+        count_all(@destination.name).must_equal(5)
+      end
+
+      printer.verify
     end
   end
 end

--- a/spec/unit/chunker_spec.rb
+++ b/spec/unit/chunker_spec.rb
@@ -6,124 +6,122 @@ require File.expand_path(File.dirname(__FILE__)) + '/unit_helper'
 require 'lhm/table'
 require 'lhm/migration'
 require 'lhm/chunker'
+require 'lhm/throttler'
 
 describe Lhm::Chunker do
   include UnitHelper
 
   before(:each) do
-    @origin      = Lhm::Table.new("origin")
-    @destination = Lhm::Table.new("destination")
-    @migration   = Lhm::Migration.new(@origin, @destination, "id")
-    @chunker     = Lhm::Chunker.new(@migration, nil, { :start => 1, :limit => 10 })
+    @origin = Lhm::Table.new('foo')
+    @destination = Lhm::Table.new('bar')
+    @migration = Lhm::Migration.new(@origin, @destination, 'id')
+    @connection = MiniTest::Mock.new
+    # This is a poor man's stub
+    @throttler = Object.new
+    def @throttler.run
+      # noop
+    end
+    def @throttler.stride
+      1
+    end
+    @chunker = Lhm::Chunker.new(@migration, @connection, :throttler => @throttler,
+                                                         :start     => 1,
+                                                         :limit     => 10)
   end
 
-  describe "copy into" do
-    before(:each) do
-      @origin.columns["secret"] = { :metadata => "VARCHAR(255)"}
-      @destination.columns["secret"] = { :metadata => "VARCHAR(255)"}
-    end
-
-    it "should copy the correct range and column" do
-      @chunker.copy(from = 1, to = 100).must_equal(
-        "insert ignore into `destination` (`secret`) " +
-        "select origin.`secret` from `origin` " +
-        "where origin.`id` between 1 and 100"
-      )
-    end
-  end
-
-  describe "copy into with a different column to order by" do
-    before(:each) do
-      @migration   = Lhm::Migration.new(@origin, @destination, "weird_id")
-      @chunker     = Lhm::Chunker.new(@migration, nil, { :start => 1, :limit => 10 })
-      @origin.columns["secret"] = { :metadata => "VARCHAR(255)"}
-      @destination.columns["secret"] = { :metadata => "VARCHAR(255)"}
-    end
-
-    it "should copy the correct range and column" do
-      @chunker.copy(from = 1, to = 100).must_equal(
-        "insert ignore into `destination` (`secret`) " +
-        "select origin.`secret` from `origin` " +
-        "where origin.`weird_id` between 1 and 100"
-      )
-    end
-  end
-
-
-  describe "invalid" do
-    before do
-      @chunker = Lhm::Chunker.new(@migration, nil, { :start => 0, :limit => -1 })
-    end
-
-    it "should have zero chunks" do
-      @chunker.traversable_chunks_size.must_equal 0
-    end
-
-    it "should not iterate" do
-      @chunker.up_to do |bottom, top|
-        raise "should not iterate"
+  describe '#run' do
+    it 'chunks the result set according to the stride size' do
+      def @throttler.stride
+        2
       end
-    end
-  end
 
-  describe "one" do
-    before do
-      @chunker = Lhm::Chunker.new(@migration, nil, {
-        :stride => 100_000, :start => 1, :limit => 300_000
-      })
-    end
-
-    it "should have one chunk" do
-      @chunker.traversable_chunks_size.must_equal 3
-    end
-
-    it "should lower bound chunk on 1" do
-      @chunker.bottom(chunk = 1).must_equal 1
-    end
-
-    it "should upper bound chunk on 100" do
-      @chunker.top(chunk = 1).must_equal 100_000
-    end
-  end
-
-  describe "two" do
-    before do
-      @chunker = Lhm::Chunker.new(@migration, nil, {
-        :stride => 100_000, :start => 2, :limit => 150_000
-      })
-    end
-
-    it "should have two chunks" do
-      @chunker.traversable_chunks_size.must_equal 2
-    end
-
-    it "should lower bound second chunk on 100_000" do
-      @chunker.bottom(chunk = 2).must_equal 100_002
-    end
-
-    it "should upper bound second chunk on 150_000" do
-      @chunker.top(chunk = 2).must_equal 150_000
-    end
-  end
-
-  describe "iterating" do
-    before do
-      @chunker = Lhm::Chunker.new(@migration, nil, {
-        :stride => 100, :start => 53, :limit => 121
-      })
-    end
-
-    it "should iterate" do
-      @chunker.up_to do |bottom, top|
-        bottom.must_equal 53
-        top.must_equal 121
+      @connection.expect(:update, 2) do |stmt|
+        stmt = stmt.first if stmt.is_a?(Array)
+        stmt =~ /between 1 and 2/
       end
-    end
-  end
+      @connection.expect(:update, 2) do |stmt|
+        stmt = stmt.first if stmt.is_a?(Array)
+        stmt =~ /between 3 and 4/
+      end
+      @connection.expect(:update, 2) do |stmt|
+        stmt = stmt.first if stmt.is_a?(Array)
+        stmt =~ /between 5 and 6/
+      end
+      @connection.expect(:update, 2) do |stmt|
+        stmt = stmt.first if stmt.is_a?(Array)
+        stmt =~ /between 7 and 8/
+      end
+      @connection.expect(:update, 2) do |stmt|
+        stmt = stmt.first if stmt.is_a?(Array)
+        stmt =~ /between 9 and 10/
+      end
 
-  describe "throttling" do
-    it "should default to 100 milliseconds" do
-      @chunker.throttle_seconds.must_equal 0.1
+      @chunker.run
+      @connection.verify
+    end
+
+    it 'handles stride changes during execution' do
+      # roll our own stubbing
+      def @throttler.stride
+        @run_count ||= 0
+        @run_count = @run_count + 1
+        if @run_count > 1
+          3
+        else
+          2
+        end
+      end
+
+      @connection.expect(:update, 2) do |stmt|
+        stmt = stmt.first if stmt.is_a?(Array)
+        stmt =~ /between 1 and 2/
+      end
+      @connection.expect(:update, 2) do |stmt|
+        stmt = stmt.first if stmt.is_a?(Array)
+        stmt =~ /between 3 and 5/
+      end
+      @connection.expect(:update, 2) do |stmt|
+        stmt = stmt.first if stmt.is_a?(Array)
+        stmt =~ /between 6 and 8/
+      end
+      @connection.expect(:update, 2) do |stmt|
+        stmt = stmt.first if stmt.is_a?(Array)
+        stmt =~ /between 9 and 10/
+      end
+
+      @chunker.run
+      @connection.verify
+    end
+
+    it 'correctly copies single record tables' do
+      @chunker = Lhm::Chunker.new(@migration, @connection, :throttler => @throttler,
+                                                           :start     => 1,
+                                                           :limit     => 1)
+
+      @connection.expect(:update, 1) do |stmt|
+        stmt = stmt.first if stmt.is_a?(Array)
+        stmt =~ /between 1 and 1/
+      end
+
+      @chunker.run
+      @connection.verify
+    end
+
+    it "doesn't mess with inner join filters" do
+      @chunker = Lhm::Chunker.new(@migration, @connection, :throttler => @throttler,
+                                                           :start     => 1,
+                                                           :limit     => 2)
+      @connection.expect(:update, 1) do |stmt|
+        stmt = stmt.first if stmt.is_a?(Array)
+        stmt =~ /inner join bar on foo.id = bar.foo_id and/
+      end
+
+      def @migration.conditions
+        'inner join bar on foo.id = bar.foo_id'
+      end
+
+      @chunker.run
+      @connection.verify
     end
   end
 end

--- a/spec/unit/printer_spec.rb
+++ b/spec/unit/printer_spec.rb
@@ -5,18 +5,19 @@ require 'lhm/printer'
 describe Lhm::Printer do
   include UnitHelper
 
-  describe "percentage printer" do
+  describe 'percentage printer' do
 
     before(:each) do
       @printer = Lhm::Printer::Percentage.new
     end
 
-    it "prints the percentage" do
+    it 'prints the percentage' do
       mock = MiniTest::Mock.new
       10.times do |i|
-        mock.expect(:write, :return_value, [String]) do |message|
-          assert_match /^\r/, message.first
-          assert_match /#{i}\/10/, message.first
+        mock.expect(:write, :return_value) do |message|
+          message = message.first if message.is_a?(Array)
+          assert_match(/^\r/, message)
+          assert_match(/#{i}\/10/, message)
         end
       end
 
@@ -25,13 +26,14 @@ describe Lhm::Printer do
       mock.verify
     end
 
-    it "always print a bigger message" do
+    it 'always print a bigger message' do
       @length = 0
       mock = MiniTest::Mock.new
-      3.times do |i|
-        mock.expect(:write, :return_value, [String]) do |message|
-          assert message.first.length >= @length
-          @length = message.first.length
+      3.times do
+        mock.expect(:write, :return_value) do |message|
+          message = message.first if message.is_a?(Array)
+          assert message.length >= @length
+          @length = message.length
         end
       end
 
@@ -45,7 +47,7 @@ describe Lhm::Printer do
       mock.verify
     end
 
-    it "prints the end message" do
+    it 'prints the end message' do
       mock = MiniTest::Mock.new
       mock.expect(:write, :return_value, [String])
       mock.expect(:write, :return_value, ["\n"])
@@ -57,16 +59,16 @@ describe Lhm::Printer do
     end
   end
 
-  describe "dot printer" do
+  describe 'dot printer' do
 
     before(:each) do
       @printer = Lhm::Printer::Dot.new
     end
 
-    it "prints the dots" do
+    it 'prints the dots' do
       mock  = MiniTest::Mock.new
       10.times do
-        mock.expect(:write, :return_value, ["."])
+        mock.expect(:write, :return_value, ['.'])
       end
 
       @printer.instance_variable_set(:@output, mock)

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -1,0 +1,202 @@
+require File.expand_path(File.dirname(__FILE__)) + '/../unit_helper'
+
+require 'lhm/throttler/slave_lag'
+
+describe Lhm::Throttler do
+  include UnitHelper
+
+  describe '#format_hosts' do
+    describe 'with only localhost hosts' do
+      it 'returns no hosts' do
+        assert_equal([], Lhm::Throttler.format_hosts(['localhost:1234', '127.0.0.1:5678']))
+      end
+    end
+
+    describe 'with only remote hosts' do
+      it 'returns remote hosts' do
+        assert_equal(['server.example.com', 'anotherserver.example.com'], Lhm::Throttler.format_hosts(['server.example.com:1234', 'anotherserver.example.com']))
+      end
+    end
+  end
+end
+
+describe Lhm::Throttler::Slave do
+  include UnitHelper
+
+  before :each do
+    def get_config
+      lambda { {'username' => 'user', 'password' => 'pw', 'database' => 'db'} }
+    end
+  end
+
+  describe "#client" do
+    before do
+      class TestMysql2Client
+        def initialize(config)
+          raise Mysql2::Error.new("connection error")
+        end
+      end
+    end
+
+    describe 'on connection error' do
+      it 'logs and returns nil' do
+        test_client = lambda { |config|
+          TestMysql2Client.new(config)
+        }
+        Mysql2::Client.stub :new, test_client do
+          assert_send([Lhm.logger, :info, "Error connecting to slave: connection error"])
+          assert_nil(Lhm::Throttler::Slave.new('slave', lambda { {} }).connection)
+        end
+      end
+    end
+
+    describe 'with proper config' do
+      it "creates a new Mysql2::Client" do
+        client_assertion = lambda { |config|
+          assert_equal(config, {:host => 'slave', :username => 'user', :password => 'pw', :database => 'db'})
+        }
+        Mysql2::Client.stub :new, client_assertion do
+          Lhm::Throttler::Slave.new('slave', get_config)
+        end
+      end
+    end
+  end
+
+  describe "#connection" do
+    before do
+      class Connection
+        def self.query(query)
+          if query == Lhm::Throttler::Slave::SQL_SELECT_MAX_SLAVE_LAG
+            [{'Seconds_Behind_Master' => 20}]
+          elsif query == Lhm::Throttler::Slave::SQL_SELECT_SLAVE_HOSTS
+            [{'host' => '1.1.1.1:80'}]
+          end
+        end
+      end
+
+      @slave = Lhm::Throttler::Slave.new('slave', get_config)
+      @slave.instance_variable_set(:@connection, Connection)
+    end
+
+    describe "#lag" do
+      it "returns the slave lag" do
+        assert_equal([20], @slave.lag)
+      end
+    end
+
+    describe "#slave_hosts" do
+      it "returns the hosts" do
+        assert_equal(['1.1.1.1'], @slave.slave_hosts)
+      end
+    end
+  end
+end
+
+describe Lhm::Throttler::SlaveLag do
+  include UnitHelper
+
+  before :each do
+    @throttler = Lhm::Throttler::SlaveLag.new
+  end
+
+  describe '#throttle_seconds' do
+    describe 'with no slave lag' do
+      before do
+        def @throttler.max_current_slave_lag
+          0
+        end
+      end
+
+      it 'does not alter the currently set timeout' do
+        timeout = @throttler.timeout_seconds
+        assert_equal(timeout, @throttler.send(:throttle_seconds))
+      end
+    end
+
+    describe 'with a large slave lag' do
+      before do
+        def @throttler.max_current_slave_lag
+          100
+        end
+      end
+
+      it 'doubles the currently set timeout' do
+        timeout = @throttler.timeout_seconds
+        assert_equal(timeout * 2, @throttler.send(:throttle_seconds))
+      end
+
+      it 'does not increase the timeout past the maximum' do
+        @throttler.timeout_seconds = Lhm::Throttler::SlaveLag::MAX_TIMEOUT
+        assert_equal(Lhm::Throttler::SlaveLag::MAX_TIMEOUT, @throttler.send(:throttle_seconds))
+      end
+    end
+
+    describe 'with no slave lag after it has previously been increased' do
+      before do
+        def @throttler.max_current_slave_lag
+          0
+        end
+      end
+
+      it 'halves the currently set timeout' do
+        @throttler.timeout_seconds *= 2 * 2
+        timeout = @throttler.timeout_seconds
+        assert_equal(timeout / 2, @throttler.send(:throttle_seconds))
+      end
+
+      it 'does not decrease the timeout past the minimum on repeated runs' do
+        @throttler.timeout_seconds = Lhm::Throttler::SlaveLag::INITIAL_TIMEOUT * 2
+        assert_equal(Lhm::Throttler::SlaveLag::INITIAL_TIMEOUT, @throttler.send(:throttle_seconds))
+        assert_equal(Lhm::Throttler::SlaveLag::INITIAL_TIMEOUT, @throttler.send(:throttle_seconds))
+      end
+    end
+  end
+
+  describe '#get_slaves' do
+    describe 'with no slaves' do
+      before do
+        def @throttler.master_slave_hosts
+          []
+        end
+      end
+
+      it 'returns no slaves' do
+        assert_equal([], @throttler.send(:get_slaves))
+      end
+    end
+
+    describe 'with multiple slaves' do
+      before do
+        class TestSlave
+          attr_reader :host, :connection
+
+          def initialize(host, get_config)
+            @host = host
+            @connection = 'conn' if @host
+          end
+
+          def slave_hosts
+            if @host == '1.1.1.1'
+              ['1.1.1.2', '1.1.1.3']
+            else
+              nil
+            end
+          end
+        end
+
+        def @throttler.master_slave_hosts
+          ['1.1.1.1', '1.1.1.4']
+        end
+      end
+
+      it 'returns the slave instances' do
+        create_slave = lambda { |host, config|
+          TestSlave.new(host, config)
+        }
+        Lhm::Throttler::Slave.stub :new, create_slave do
+          assert_equal(["1.1.1.4", "1.1.1.1", "1.1.1.3", "1.1.1.2"], @throttler.send(:get_slaves).map(&:host))
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/throttler_spec.rb
+++ b/spec/unit/throttler_spec.rb
@@ -1,0 +1,124 @@
+require File.expand_path(File.dirname(__FILE__)) + '/unit_helper'
+
+require 'lhm/throttler'
+
+describe Lhm::Throttler do
+  include UnitHelper
+
+  before :each do
+    @mock = Class.new do
+      extend Lhm::Throttler
+    end
+
+    @conn = Class.new do
+      def execute
+      end
+    end
+  end
+
+  describe '#setup_throttler' do
+    describe 'when passing a time_throttler key' do
+      before do
+        @mock.setup_throttler(:time_throttler, delay: 2)
+      end
+
+      it 'instantiates the time throttle' do
+        @mock.throttler.class.must_equal Lhm::Throttler::Time
+      end
+
+      it 'returns 2 seconds as time' do
+        @mock.throttler.timeout_seconds.must_equal 2
+      end
+    end
+
+    describe 'when passing a slave_lag_throttler key' do
+      before do
+        @mock.setup_throttler(:slave_lag_throttler, allowed_lag: 20)
+      end
+
+      it 'instantiates the slave_lag throttle' do
+        @mock.throttler.class.must_equal Lhm::Throttler::SlaveLag
+      end
+
+      it 'returns 20 seconds as allowed_lag' do
+        @mock.throttler.allowed_lag.must_equal 20
+      end
+    end
+
+    describe 'when passing a time_throttler instance' do
+
+      before do
+        @instance = Class.new(Lhm::Throttler::Time) do
+          def timeout_seconds
+            0
+          end
+        end.new
+
+        @mock.setup_throttler(@instance)
+      end
+
+      it 'returns the instace given' do
+        @mock.throttler.must_equal @instance
+      end
+
+      it 'returns 0 seconds as time' do
+        @mock.throttler.timeout_seconds.must_equal 0
+      end
+    end
+
+    describe 'when passing a slave_lag_throttler instance' do
+
+      before do
+        @instance = Lhm::Throttler::SlaveLag.new
+        def @instance.timeout_seconds
+          0
+        end
+
+        @mock.setup_throttler(@instance)
+      end
+
+      it 'returns the instace given' do
+        @mock.throttler.must_equal @instance
+      end
+
+      it 'returns 0 seconds as time' do
+        @mock.throttler.timeout_seconds.must_equal 0
+      end
+    end
+
+    describe 'when passing a time_throttler class' do
+
+      before do
+        @klass = Class.new(Lhm::Throttler::Time)
+        @mock.setup_throttler(@klass)
+      end
+
+      it 'has the same class as given' do
+        @mock.throttler.class.must_equal @klass
+      end
+    end
+
+    describe 'when passing a slave_lag_throttler class' do
+
+      before do
+        @klass = Class.new(Lhm::Throttler::SlaveLag)
+        @mock.setup_throttler(@klass)
+      end
+
+      it 'has the same class as given' do
+        @mock.throttler.class.must_equal @klass
+      end
+    end
+  end
+
+  describe '#throttler' do
+
+    it 'returns the default Time based' do
+      @mock.throttler.class.must_equal Lhm::Throttler::Time
+    end
+
+    it 'should default to 100 milliseconds' do
+      @mock.throttler.timeout_seconds.must_equal 0.1
+    end
+  end
+end


### PR DESCRIPTION
This gets the slave lag throttler working with our fork.  The changes I added to soundcloud/lhm are here: https://github.com/jordanwheeler/lhm/pull/1, but our fork is behind that, so I had to add other changes to get  the throttler working properly.  I added some of the changes that have been made upstream in `chunker.rb` so that works properly now - `throttler.rb`, `time.rb`, `slave_lag.rb` are all new.  I updated the tests as well, so this PR has a lot of additions now.

@camilo @Shopify/datastores 
I can't seem to @arthurnn here.