### PR TITLE
add method to drop aborted tables only

### DIFF
--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -3,32 +3,80 @@
 
 require File.expand_path(File.dirname(__FILE__)) + '/integration_helper'
 
-require 'lhm'
-
-describe Lhm, "cleanup" do
+describe Lhm, 'cleanup' do
   include IntegrationHelper
   before(:each) { connect_master! }
 
-  describe "changes" do
+  describe 'changes' do
     before(:each) do
       table_create(:users)
-      Lhm.change_table(:users, :atomic_switch => false) do |t|
-        t.add_column(:logins, "INT(12) DEFAULT '0'")
-        t.add_index(:logins)
+      simulate_failed_migration do
+        Lhm.change_table(:users, :atomic_switch => false) do |t|
+          t.add_column(:logins, "INT(12) DEFAULT '0'")
+          t.add_index(:logins)
+        end
       end
     end
 
-    it "should show temporary tables" do
+    after(:each) do
+      Lhm.cleanup(true)
+    end
+
+    it 'should show temporary tables' do
       output = capture_stdout do
         Lhm.cleanup
       end
-      output.must_include("Existing LHM backup tables")
+      output.must_include('Existing LHM backup tables')
       output.must_match(/lhma_[0-9_]*_users/)
     end
 
-    it "should delete temporary tables" do
+    it 'should show temporary tables within range' do
+      table = OpenStruct.new(:name => 'users')
+      table_name = Lhm::Migration.new(table, nil, nil, {}, Time.now - 172800).archive_name
+      table_rename(:users, table_name)
+
+      output = capture_stdout do
+        Lhm.cleanup false, { :until => Time.now - 86400 }
+      end
+      output.must_include('Existing LHM backup tables')
+      output.must_match(/lhma_[0-9_]*_users/)
+    end
+
+    it 'should exclude temporary tables outside range' do
+      table = OpenStruct.new(:name => 'users')
+      table_name = Lhm::Migration.new(table, nil, nil, {}, Time.now).archive_name
+      table_rename(:users, table_name)
+
+      output = capture_stdout do
+        Lhm.cleanup false, { :until => Time.now - 172800 }
+      end
+      output.must_include('Existing LHM backup tables')
+      output.wont_match(/lhma_[0-9_]*_users/)
+    end
+
+    it 'should show temporary triggers' do
+      output = capture_stdout do
+        Lhm.cleanup
+      end
+      output.must_include('Existing LHM triggers')
+      output.must_include('lhmt_ins_users')
+      output.must_include('lhmt_del')
+      output.must_include('lhmt_upd_users')
+    end
+
+    it 'should delete temporary tables' do
       Lhm.cleanup(true).must_equal(true)
       Lhm.cleanup.must_equal(true)
+    end
+
+    it 'should only remove lhmn_ tables with #cleanup_aborted' do
+      table_rename(:users, 'lhmn_users')
+      output = capture_stdout do
+        Lhm.cleanup_aborted false
+      end
+      output.must_include('Existing LHM tables')
+      output.must_match(/lhmn_users/)
+      output.wont_match(/lhma_[0-9_]*_users/)
     end
   end
 end


### PR DESCRIPTION
A task exists in the Lhm codebase to clean up all `lhma_` and `lhmn_` tables.  `lhma_` tables are backup tables left over after an Lhm finishes.  We like to keep them around for a week just to be safe, and we've got a script running on the machines that removes them automatically when 7 days pass.

All I'm changing is that instead of always searching for tables with the `/^lhm(a|n)_/` pattern, we'll just search for `/^lhmn_/` tables when we run this task from Shopify.  I've updated the cleanup code and tests so that they match soundcloud/lhm, so there are a bunch of changes, but all I've _really_ changed is that instead of having one `cleanup` method, we've got a `cleanup_aborted` method that will only check for the `lhmn_` pattern.

@camilo @jasonhl @sroysen 
