### PR TITLE
Rebase upstream

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -46,7 +46,7 @@ module Lhm
   # @raise [Error] Raises Lhm::Error in case of a error and aborts the migration
   def change_table(table_name, options = {}, &block)
     origin = Table.parse(table_name, connection)
-    invoker = Invoker.new(origin, connection)
+    invoker = Invoker.new(origin, connection, options)
     block.call(invoker.migrator)
     invoker.run(options)
     true

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -116,6 +116,7 @@ module Lhm
         params = (defined?(@@logger_params) && @@logger_params) ? @@logger_params : DEFAULT_LOGGER_OPTIONS
         logger = Logger.new(params[:file])
         logger.level = params[:level]
+        logger.formatter = nil
         logger
       end
   end

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -102,16 +102,20 @@ module Lhm
       end
   end
 
-  def self.logger=(new_logger)
+  def logger=(new_logger)
     @@logger = new_logger
   end
 
-  def self.logger
+  def logger_params=(params)
+    @@logger_params = params
+  end
+
+  def logger
     @@logger ||=
       begin
-        logger = Logger.new(DEFAULT_LOGGER_OPTIONS[:file])
-        logger.level = DEFAULT_LOGGER_OPTIONS[:level]
-        logger.formatter = nil
+        params = (defined?(@@logger_params) && @@logger_params) ? @@logger_params : DEFAULT_LOGGER_OPTIONS
+        logger = Logger.new(params[:file])
+        logger.level = params[:level]
         logger
       end
   end

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -39,6 +39,8 @@ module Lhm
   #   Use atomic switch to rename tables (defaults to: true)
   #   If using a version of mysql affected by atomic switch bug, LHM forces user
   #   to set this option (see SqlHelper#supports_atomic_switch?)
+  # @option options [String] :order_column
+  #   Column name to order records by. This column must be unique for every record (defaults to: "id")
   # @yield [Migrator] Yielded Migrator object records the changes
   # @return [Boolean] Returns true if the migration finishes
   # @raise [Error] Raises Lhm::Error in case of a error and aborts the migration

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -52,8 +52,8 @@ module Lhm
     end
 
     def copy(lowest, highest)
-      "insert ignore into `#{ destination_name }` (#{ columns }) " +
-      "select #{ select_columns } from `#{ origin_name }` " +
+      "insert ignore into `#{ destination_name }` (#{ destination_columns }) " +
+      "select #{ origin_columns } from `#{ origin_name }` " +
       "#{ conditions } #{ origin_name }.`#{ @migration.order_column }` between #{ lowest } and #{ highest }"
     end
 
@@ -106,18 +106,6 @@ module Lhm
       if @start && @limit && @start > @limit
         error('impossible chunk options (limit must be greater than start)')
       end
-    end
-
-    def execute
-      up_to do |lowest, highest|
-        affected_rows = @connection.update(copy(lowest, highest))
-
-        if affected_rows > 0
-          sleep(throttle_seconds)
-        end
-        @printer.notify(lowest, @limit)
-      end
-      @printer.end
     end
   end
 end

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -115,7 +115,7 @@ module Lhm
         if affected_rows > 0
           sleep(throttle_seconds)
         end
-        @printer.notify(lowest, highest)
+        @printer.notify(lowest, @limit)
       end
       @printer.end
     end

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -52,18 +52,18 @@ module Lhm
     end
 
     def copy(lowest, highest)
-      "insert ignore into `#{ destination_name }` (#{ destination_columns }) " \
-      "select #{ origin_columns } from `#{ origin_name }` " \
-      "#{ conditions } `#{ origin_name }`.`id` between #{ lowest } and #{ highest }"
+      "insert ignore into `#{ destination_name }` (#{ columns }) " +
+      "select #{ select_columns } from `#{ origin_name }` " +
+      "#{ conditions } #{ origin_name }.`#{ @migration.order_column }` between #{ lowest } and #{ highest }"
     end
 
     def select_start
-      start = connection.select_value("select min(id) from `#{ origin_name }`")
+      start = connection.select_value("select min(#{ @migration.order_column }) from #{ origin_name }")
       start ? start.to_i : nil
     end
 
     def select_limit
-      limit = connection.select_value("select max(id) from `#{ origin_name }`")
+      limit = connection.select_value("select max(#{ @migration.order_column }) from #{ origin_name }")
       limit ? limit.to_i : nil
     end
 

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -107,5 +107,17 @@ module Lhm
         error('impossible chunk options (limit must be greater than start)')
       end
     end
+
+    def execute
+      up_to do |lowest, highest|
+        affected_rows = @connection.update(copy(lowest, highest))
+
+        if affected_rows > 0
+          sleep(throttle_seconds)
+        end
+        @printer.notify(lowest, highest)
+      end
+      @printer.end
+    end
   end
 end

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -59,7 +59,7 @@ module Lhm
         create trigger `#{ trigger(:del) }`
         after delete on `#{ @origin.name }` for each row
         delete ignore from `#{ @destination.name }` #{ SqlHelper.annotation }
-        where `#{ @destination.name }`.`id` = OLD.`id`
+        where `#{ @destination.name }`.`#{ @destination.pk }` = OLD.`#{ @origin.pk }`
       }
     end
 

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -17,6 +17,7 @@ module Lhm
       @intersection = migration.intersection
       @origin = migration.origin
       @destination = migration.destination
+      @order_column = migration.order_column
       @connection = connection
     end
 
@@ -59,7 +60,7 @@ module Lhm
         create trigger `#{ trigger(:del) }`
         after delete on `#{ @origin.name }` for each row
         delete ignore from `#{ @destination.name }` #{ SqlHelper.annotation }
-        where `#{ @destination.name }`.`#{ @destination.pk }` = OLD.`#{ @origin.pk }`
+        where `#{ @destination.name }`.`#{ @order_column }` = OLD.`#{ @order_column }`
       }
     end
 

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -19,9 +19,9 @@ module Lhm
 
     attr_reader :migrator, :connection
 
-    def initialize(origin, connection)
+    def initialize(origin, connection, options)
       @connection = connection
-      @migrator = Migrator.new(origin, connection)
+      @migrator = Migrator.new(origin, connection, options)
     end
 
     def set_session_lock_wait_timeouts

--- a/lib/lhm/migration.rb
+++ b/lib/lhm/migration.rb
@@ -5,12 +5,13 @@ require 'lhm/intersection'
 
 module Lhm
   class Migration
-    attr_reader :origin, :destination, :conditions, :renames
+    attr_reader :origin, :destination, :conditions, :order_column, :renames
 
-    def initialize(origin, destination, conditions = nil, renames = {}, time = Time.now)
+    def initialize(origin, destination, order_column, conditions = nil, renames = {}, time = Time.now)
       @origin = origin
       @destination = destination
       @conditions = conditions
+      @order_column = order_column
       @start = time
       @renames = renames
     end

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -15,9 +15,8 @@ module Lhm
       @ddl = ddl
     end
 
-    def satisfies_id_column_requirement?
-      !!((id = columns['id']) &&
-        id[:type] =~ /(bigint|int)\(\d+\)/)
+    def satisfies_primary_key?
+      @pk.is_a?(String) && !!(@columns[@pk][:type] =~ /int\(\d+\)/)
     end
 
     def destination_name

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -16,7 +16,11 @@ module Lhm
     end
 
     def satisfies_primary_key?
-      @pk.is_a?(String) && !!(@columns[@pk][:type] =~ /int\(\d+\)/)
+      @pk.is_a?(String) && numeric_type?(@columns[@pk][:type])
+    end
+
+    def can_use_order_column?(column)
+      numeric_type?(@columns[column][:type])
     end
 
     def destination_name
@@ -108,8 +112,16 @@ module Lhm
           defn[column_name]
         end
 
-        keys.length == 1 ? keys.first : keys
+        case keys.length
+        when 0 then nil
+        when 1 then keys.first
+        else keys
+        end
       end
+    end
+
+    def numeric_type?(type)
+      !!(type.match(/int\(\d+\)|decimal|numeric|float|double|integer/))
     end
   end
 end

--- a/spec/fixtures/no_primary_key.ddl
+++ b/spec/fixtures/no_primary_key.ddl
@@ -1,0 +1,4 @@
+CREATE TABLE `no_primary_key` (
+  `foreign_id` int(11) NOT NULL,
+  `value` int(11) NOT NULL DEFAULT '0'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/primary_keys.ddl
+++ b/spec/fixtures/primary_keys.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `primary_keys` (
+  `weird_id` int(11) NOT NULL AUTO_INCREMENT,
+  `origin` int(11) DEFAULT NULL,
+  `common` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`weird_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -17,7 +17,7 @@ describe Lhm::AtomicSwitcher do
       Thread.abort_on_exception = true
       @origin      = table_create('origin')
       @destination = table_create('destination')
-      @migration   = Lhm::Migration.new(@origin, @destination, "id")
+      @migration   = Lhm::Migration.new(@origin, @destination, 'id')
       Lhm.logger = Logger.new('/dev/null')
       @connection.execute('SET GLOBAL innodb_lock_wait_timeout=3')
       @connection.execute('SET GLOBAL lock_wait_timeout=3')

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -17,7 +17,7 @@ describe Lhm::AtomicSwitcher do
       Thread.abort_on_exception = true
       @origin      = table_create('origin')
       @destination = table_create('destination')
-      @migration   = Lhm::Migration.new(@origin, @destination)
+      @migration   = Lhm::Migration.new(@origin, @destination, "id")
       Lhm.logger = Logger.new('/dev/null')
       @connection.execute('SET GLOBAL innodb_lock_wait_timeout=3')
       @connection.execute('SET GLOBAL lock_wait_timeout=3')

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -14,7 +14,7 @@ describe Lhm::Chunker do
     before(:each) do
       @origin = table_create(:origin)
       @destination = table_create(:destination)
-      @migration = Lhm::Migration.new(@origin, @destination)
+      @migration = Lhm::Migration.new(@origin, @destination, "id")
     end
 
     it 'should copy 23 rows from origin to destination with time based throttler' do

--- a/spec/integration/entangler_spec.rb
+++ b/spec/integration/entangler_spec.rb
@@ -16,7 +16,7 @@ describe Lhm::Entangler do
     before(:each) do
       @origin = table_create('origin')
       @destination = table_create('destination')
-      @migration = Lhm::Migration.new(@origin, @destination)
+      @migration = Lhm::Migration.new(@origin, @destination, "id")
       @entangler = Lhm::Entangler.new(@migration, connection)
     end
 

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -157,6 +157,14 @@ module IntegrationHelper
     >)
   end
 
+  def with_per_thread_lhm_connection
+    pool = ActiveRecord::Base.establish_connection(adapter: 'mysql2', database: 'lhm')
+    pool.with_connection do |conn|
+      lhm_connection = Lhm::Connection.new(conn)
+      yield  lhm_connection
+    end
+  end
+
   #
   # Environment
   #

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -8,6 +8,8 @@ $password = YAML.load_file(File.expand_path(File.dirname(__FILE__)) + '/database
 require 'lhm/table'
 require 'lhm/sql_helper'
 
+Lhm.logger_params = {level: Logger::FATAL, file: '/dev/null'}
+
 module IntegrationHelper
   #
   # Connectivity

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -305,8 +305,24 @@ describe Lhm do
       end
     end
 
-    describe 'parallel' do
-      it 'should perserve inserts during migration' do
+    it "should change a table with a no primary key" do
+      table_create(:no_primary_key)
+
+      Lhm.change_table(:no_primary_key, :atomic_switch => false, :order_column => 'foreign_id') do |t|
+        t.change_column(:value, "text")
+      end
+
+      slave do
+        table_read(:no_primary_key).columns["value"].must_equal({
+          :type => "text",
+          :is_nullable => "YES",
+          :column_default => nil
+        })
+      end
+    end
+
+    describe "parallel" do
+      it "should perserve inserts during migration" do
         50.times { |n| execute("insert into users set reference = '#{ n }'") }
 
         insert = Thread.new do

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -352,6 +352,22 @@ describe Lhm do
           count_all(:users).must_equal(40)
         end
       end
+
+      it "should change a table with a primary key other than id" do
+        table_create(:primary_keys)
+
+        Lhm.change_table(:primary_keys, :atomic_switch => false) do |t|
+          t.change_column(:weird_id, "int(5)")
+        end
+
+        slave do
+          table_read(:primary_keys).columns["weird_id"].must_equal({
+            :type => "int(5)",
+            :is_nullable => "NO",
+            :column_default => "0"
+          })
+        end
+      end
     end
   end
 end

--- a/spec/integration/locked_switcher_spec.rb
+++ b/spec/integration/locked_switcher_spec.rb
@@ -24,7 +24,7 @@ describe Lhm::LockedSwitcher do
     before(:each) do
       @origin = table_create('origin')
       @destination = table_create('destination')
-      @migration = Lhm::Migration.new(@origin, @destination)
+      @migration = Lhm::Migration.new(@origin, @destination, "id")
     end
 
     it 'rename origin to archive' do

--- a/spec/integration/table_spec.rb
+++ b/spec/integration/table_spec.rb
@@ -31,12 +31,12 @@ describe Lhm::Table do
       end
 
       it 'should return true for method that should be renamed' do
-        @table.satisfies_id_column_requirement?.must_equal true
+        @table.satisfies_primary_key?.must_equal true
       end
 
       it 'should support bigint tables' do
         @table = table_create(:bigint_table)
-        @table.satisfies_id_column_requirement?.must_equal true
+        @table.satisfies_primary_key?.must_equal true
       end
     end
 
@@ -47,7 +47,7 @@ describe Lhm::Table do
 
       it 'should return false for a non-int id column' do
         @table = table_create(:wo_id_int_column)
-        @table.satisfies_id_column_requirement?.must_equal false
+        @table.satisfies_primary_key?.must_equal false
       end
     end
   end

--- a/spec/unit/chunker_spec.rb
+++ b/spec/unit/chunker_spec.rb
@@ -141,4 +141,20 @@ describe Lhm::Chunker do
       @connection.verify
     end
   end
+
+  describe "copy into with a different column to order by" do
+    before(:each) do
+      @chunker     = Lhm::Chunker.new(@migration, nil, { :start => 1, :limit => 10, :order_column => 'weird_id' })
+      @origin.columns["secret"] = { :metadata => "VARCHAR(255)"}
+      @destination.columns["secret"] = { :metadata => "VARCHAR(255)"}
+    end
+
+    it "should copy the correct range and column" do
+      @chunker.copy(from = 1, to = 100).must_equal(
+        "insert ignore into `destination` (`secret`) " +
+        "select origin.`secret` from `origin` " +
+        "where origin.`weird_id` between 1 and 100"
+      )
+    end
+  end
 end

--- a/spec/unit/chunker_spec.rb
+++ b/spec/unit/chunker_spec.rb
@@ -14,7 +14,7 @@ describe Lhm::Chunker do
   before(:each) do
     @origin = Lhm::Table.new('foo')
     @destination = Lhm::Table.new('bar')
-    @migration = Lhm::Migration.new(@origin, @destination)
+    @migration = Lhm::Migration.new(@origin, @destination, "id")
     @connection = MiniTest::Mock.new
     # This is a poor man's stub
     @throttler = Object.new
@@ -144,7 +144,8 @@ describe Lhm::Chunker do
 
   describe "copy into with a different column to order by" do
     before(:each) do
-      @chunker     = Lhm::Chunker.new(@migration, nil, { :start => 1, :limit => 10, :order_column => 'weird_id' })
+      @migration   = Lhm::Migration.new(@origin, @destination, "weird_id")
+      @chunker     = Lhm::Chunker.new(@migration, nil, { :start => 1, :limit => 10 })
       @origin.columns["secret"] = { :metadata => "VARCHAR(255)"}
       @destination.columns["secret"] = { :metadata => "VARCHAR(255)"}
     end

--- a/spec/unit/entangler_spec.rb
+++ b/spec/unit/entangler_spec.rb
@@ -13,7 +13,7 @@ describe Lhm::Entangler do
   before(:each) do
     @origin = Lhm::Table.new('origin')
     @destination = Lhm::Table.new('destination')
-    @migration = Lhm::Migration.new(@origin, @destination)
+    @migration = Lhm::Migration.new(@origin, @destination, 'id')
     @entangler = Lhm::Entangler.new(@migration)
   end
 

--- a/spec/unit/lhm_spec.rb
+++ b/spec/unit/lhm_spec.rb
@@ -6,17 +6,26 @@ describe Lhm do
 
   before(:each) do
     Lhm.remove_class_variable :@@logger if Lhm.class_variable_defined? :@@logger
+    Lhm.remove_class_variable :@@logger_params if Lhm.class_variable_defined? :@@logger_params
   end
 
   describe 'logger' do
 
-    it 'should use the default parameters if no logger explicitly set' do
+    it "should use the default parameters if @@logger_params is not set" do
       Lhm.logger.must_be_kind_of Logger
       Lhm.logger.level.must_equal Logger::INFO
-      Lhm.logger.instance_eval { @logdev }.dev.must_equal STDOUT
+      Lhm.logger.instance_eval{ @logdev }.dev.must_equal STDOUT
     end
 
-    it 'should use s new logger if set' do
+    it "should use the parameters defined in @@logger_params" do
+      Lhm.logger_params =  {level: Logger::ERROR, file: 'omg.ponies' }
+
+      Lhm.logger.level.must_equal Logger::ERROR
+      Lhm.logger.instance_eval{ @logdev }.dev.must_be_kind_of File
+      Lhm.logger.instance_eval{ @logdev }.dev.path.must_equal 'omg.ponies'
+    end
+
+    it 'should use a new logger if set' do
       l = Logger.new('omg.ponies')
       l.level = Logger::ERROR
       Lhm.logger = l

--- a/spec/unit/migration_spec.rb
+++ b/spec/unit/migration_spec.rb
@@ -13,7 +13,7 @@ describe Lhm::Migration do
     @start = Time.now
     @origin = Lhm::Table.new('origin')
     @destination = Lhm::Table.new('destination')
-    @migration = Lhm::Migration.new(@origin, @destination, nil, @start)
+    @migration = Lhm::Migration.new(@origin, @destination, 'id', nil, @start)
   end
 
   it 'should name archive' do
@@ -22,7 +22,7 @@ describe Lhm::Migration do
   end
 
   it 'should limit table name to 64 characters' do
-    migration = Lhm::Migration.new(OpenStruct.new(:name => 'a_very_very_long_table_name_that_should_make_the_LHMA_table_go_over_64_chars'), nil)
+    migration = Lhm::Migration.new(OpenStruct.new(:name => 'a_very_very_long_table_name_that_should_make_the_LHMA_table_go_over_64_chars'), nil, 'id')
     migration.archive_name.size == 64
   end
 end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -23,22 +23,23 @@ describe Lhm::Table do
     it 'should be satisfied with a single column primary key called id' do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'int(1)' } })
-      @table.satisfies_id_column_requirement?.must_equal true
+      @table.satisfies_primary_key?.must_equal true
+    end
 
-    it 'should be satisfied with a primary key not called id, as long as there is still an id' do
+    it 'should be satisfied with a primary key called something other than id' do
       @table = Lhm::Table.new('table', 'uuid')
-      set_columns(@table, { 'id' => { :type => 'int(1)' } })
-      @table.satisfies_id_column_requirement?.must_equal true
+      set_columns(@table, { 'uuid' => { :type => 'int(1)' } })
+      @table.satisfies_primary_key?.must_equal true
     end
 
     it 'should not be satisfied if id is not numeric' do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'varchar(255)' } })
-      @table.satisfies_id_column_requirement?.must_equal false
+      @table.satisfies_primary_key?.must_equal false
     end
 
     it "should not be satisfied with a non numeric primary key" do
-      @table = Lhm::Table.new("table", "id")
+      @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'varchar(255)' } })
       @table.satisfies_primary_key?.must_equal false
     end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -24,7 +24,6 @@ describe Lhm::Table do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'int(1)' } })
       @table.satisfies_id_column_requirement?.must_equal true
-    end
 
     it 'should be satisfied with a primary key not called id, as long as there is still an id' do
       @table = Lhm::Table.new('table', 'uuid')
@@ -36,6 +35,12 @@ describe Lhm::Table do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'varchar(255)' } })
       @table.satisfies_id_column_requirement?.must_equal false
+    end
+
+    it "should not be satisfied with a non numeric primary key" do
+      @table = Lhm::Table.new("table", "id")
+      set_columns(@table, { 'id' => { :type => 'varchar(255)' } })
+      @table.satisfies_primary_key?.must_equal false
     end
   end
 end


### PR DESCRIPTION
Many files in our fork were 2 years behind soundcloud/lhm.  So I rebased it, and kept our changes in (basically the ability to run a migration on a table with a primary key not named `id`, and the logger params stuff) and updated the tests and things.  And here's the end result.  There's a lot of stuff.

Tests pass, and I've manually tested by using this to run migrations in Shopify core.  I still want to try a couple other things out just to be absolutely sure, and I might try a `CHECK TABLE` next week on one of the `lhma_` tables this created just to try and verify that everything migrated correctly, but it's working fine.

There's obviously bug fixes and features in here that we've been missing, and it'll sure make these PRs I've been opening against our fork a lot cleaner.

A one line change in Shopify/shopify is also required to use this.

@camilo @arthurnn @Shopify/datastores 
