### PR TITLE
Throttle based on lag of all slaves in replication chain

### DIFF
--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -68,7 +68,8 @@ module Lhm
       end
 
       if options[:throttler]
-        options[:throttler] = Throttler::Factory.create_throttler(options[:throttler])
+        throttler_options = options[:throttler_options] || {}
+        options[:throttler] = Throttler::Factory.create_throttler(options[:throttler], throttler_options)
       else
         options[:throttler] = Lhm.throttler
       end

--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -1,5 +1,11 @@
 module Lhm
   module Throttler
+
+    def self.format_hosts(hosts)
+      hosts.map { |host| host.partition(':')[0] }
+        .delete_if { |host| host == 'localhost' || host == '127.0.0.1' }
+    end
+
     class SlaveLag
       include Command
 
@@ -15,7 +21,8 @@ module Lhm
         @timeout_seconds = INITIAL_TIMEOUT
         @stride = options[:stride] || DEFAULT_STRIDE
         @allowed_lag = options[:allowed_lag] || DEFAULT_MAX_ALLOWED_LAG
-        @slave_connections = {}
+        @slaves = {}
+        @get_config = options[:current_config]
       end
 
       def execute
@@ -23,11 +30,6 @@ module Lhm
       end
 
       private
-
-      SQL_SELECT_SLAVE_HOSTS = "SELECT host FROM information_schema.processlist WHERE command='Binlog Dump'"
-      SQL_SELECT_MAX_SLAVE_LAG = 'SHOW SLAVE STATUS'
-
-      private_constant :SQL_SELECT_SLAVE_HOSTS, :SQL_SELECT_MAX_SLAVE_LAG
 
       def throttle_seconds
         lag = max_current_slave_lag
@@ -43,55 +45,79 @@ module Lhm
         end
       end
 
-      def slave_hosts
-        slaves = get_slaves.map { |slave_host| slave_host.partition(':')[0] }
-          .delete_if { |slave| slave == 'localhost' || slave == '127.0.0.1' }
-        Lhm.logger.info "Detected slaves: #{slaves.join(',')}"
-        slaves
+      def slaves
+        @slaves[@connection] ||= get_slaves
       end
 
       def get_slaves
-        @connection.select_values(SQL_SELECT_SLAVE_HOSTS)
+        slaves = []
+        slave_hosts = master_slave_hosts
+        while slave_hosts.any? do
+          host = slave_hosts.pop
+          slave = Slave.new(host, @get_config)
+          if slaves.map(&:host).exclude?(host) && slave.connection
+            slaves << slave
+            slave_hosts << slave.slave_hosts
+            slave_hosts.flatten!
+          end
+        end
+        slaves
+      end
+
+      def master_slave_hosts
+        Throttler.format_hosts(@connection.select_values(Slave::SQL_SELECT_SLAVE_HOSTS))
       end
 
       def max_current_slave_lag
-        max = slave_hosts.map { |slave| slave_lag(slave) }.flatten.push(0).max
+        max = slaves.map { |slave| slave.lag }.flatten.push(0).max
         Lhm.logger.info "Max current slave lag: #{max}"
         max
       end
+    end
 
-      def slave_lag(slave)
-        conn = slave_connection(slave)
-        if conn.respond_to?(:exec_query)
-          result = conn.exec_query(SQL_SELECT_MAX_SLAVE_LAG)
-          result.map { |row| row['Seconds_Behind_Master'].to_i }
-        else
-          result = conn.execute(SQL_SELECT_MAX_SLAVE_LAG)
-          fetch_slave_seconds(result)
+    class Slave
+      SQL_SELECT_SLAVE_HOSTS = "SELECT host FROM information_schema.processlist WHERE command='Binlog Dump'"
+      SQL_SELECT_MAX_SLAVE_LAG = 'SHOW SLAVE STATUS'
+
+      attr_reader :host, :connection
+
+      def initialize(host, get_config=nil)
+        @host = host
+        @connection = client(config(get_config))
+      end
+
+      def slave_hosts
+        Throttler.format_hosts(query_connection(SQL_SELECT_SLAVE_HOSTS, 'host'))
+      end
+
+      def lag
+        query_connection(SQL_SELECT_MAX_SLAVE_LAG, 'Seconds_Behind_Master')
+      end
+
+      private
+
+      def client(config)
+        begin
+          Mysql2::Client.new(config)
+        rescue Mysql2::Error => e
+          Lhm.logger.info "Error connecting to #{@host}: #{e}"
+          nil
         end
-      rescue Error => e
-        raise Lhm::Error, "Unable to connect and/or query slave to determine slave lag. Migration aborting because of: #{e}"
       end
 
-      def slave_connection(slave)
-        adapter_method = defined?(Mysql2) ? 'mysql2_connection' : 'mysql_connection'
-        config = ActiveRecord::Base.connection_pool.spec.config.dup
-        config[:host] = slave
-        ActiveRecord::Base.send(adapter_method, config)
+      def config(get_config)
+        config = get_config ? get_config.call : ActiveRecord::Base.connection_pool.spec.config.dup
+        config['host'] = @host
+        config
       end
 
-      # This method fetch the Seconds_Behind_Master, when exec_query is no available, on AR 2.3.
-      def fetch_slave_seconds(result)
-        unless result.is_a? Mysql::Result
-          Lhm.logger.info "Not a Mysql::Result from the slave assuming 0 lag"
-          return 0
+      def query_connection(query, result)
+        begin
+          @connection.query(query).map { |row| row[result] }
+        rescue Error => e
+          raise Lhm::Error, "Unable to connect and/or query slave to determine slave lag. Migration aborting because of: #{e}"
         end
-
-        keys = []
-        result.each_hash { |h| keys << h['Seconds_Behind_Master'].to_i }
-        keys
       end
-
     end
   end
 end

--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -57,8 +57,7 @@ module Lhm
           slave = Slave.new(host, @get_config)
           if slaves.map(&:host).exclude?(host) && slave.connection
             slaves << slave
-            slave_hosts << slave.slave_hosts
-            slave_hosts.flatten!
+            slave_hosts.concat(slave.slave_hosts)
           end
         end
         slaves

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -179,7 +179,7 @@ describe Lhm::Throttler::SlaveLag do
             if @host == '1.1.1.1'
               ['1.1.1.2', '1.1.1.3']
             else
-              nil
+              [nil]
             end
           end
         end

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -2,6 +2,96 @@ require File.expand_path(File.dirname(__FILE__)) + '/../unit_helper'
 
 require 'lhm/throttler/slave_lag'
 
+describe Lhm::Throttler do
+  include UnitHelper
+
+  describe '#format_hosts' do
+    describe 'with only localhost hosts' do
+      it 'returns no hosts' do
+        assert_equal([], Lhm::Throttler.format_hosts(['localhost:1234', '127.0.0.1:5678']))
+      end
+    end
+
+    describe 'with only remote hosts' do
+      it 'returns remote hosts' do
+        assert_equal(['server.example.com', 'anotherserver.example.com'], Lhm::Throttler.format_hosts(['server.example.com:1234', 'anotherserver.example.com']))
+      end
+    end
+  end
+end
+
+describe Lhm::Throttler::Slave do
+  include UnitHelper
+
+  before :each do
+    def get_config
+      lambda { {'host' => 'master', 'username' => 'user', 'password' => 'pw', 'database' => 'db'} }
+    end
+  end
+
+  describe "#client" do
+    before do
+      class TestMysql2Client
+        def initialize(config)
+          raise Mysql2::Error.new("connection error")
+        end
+      end
+    end
+
+    describe 'on connection error' do
+      it 'logs and returns nil' do
+        test_client = lambda { |config|
+          TestMysql2Client.new(config)
+        }
+        Mysql2::Client.stub :new, test_client do
+          assert_send([Lhm.logger, :info, "Error connecting to slave: connection error"])
+          assert_nil(Lhm::Throttler::Slave.new('slave', lambda { {} }).connection)
+        end
+      end
+    end
+
+    describe 'with proper config' do
+      it "creates a new Mysql2::Client" do
+        client_assertion = lambda { |config|
+          assert_equal(config, {'host' => 'slave', 'username' => 'user', 'password' => 'pw', 'database' => 'db'})
+        }
+        Mysql2::Client.stub :new, client_assertion do
+          Lhm::Throttler::Slave.new('slave', get_config)
+        end
+      end
+    end
+  end
+
+  describe "#connection" do
+    before do
+      class Connection
+        def self.query(query)
+          if query == Lhm::Throttler::Slave::SQL_SELECT_MAX_SLAVE_LAG
+            [{'Seconds_Behind_Master' => 20}]
+          elsif query == Lhm::Throttler::Slave::SQL_SELECT_SLAVE_HOSTS
+            [{'host' => '1.1.1.1:80'}]
+          end
+        end
+      end
+
+      @slave = Lhm::Throttler::Slave.new('slave', get_config)
+      @slave.instance_variable_set(:@connection, Connection)
+    end
+
+    describe "#lag" do
+      it "returns the slave lag" do
+        assert_equal([20], @slave.lag)
+      end
+    end
+
+    describe "#slave_hosts" do
+      it "returns the hosts" do
+        assert_equal(['1.1.1.1'], @slave.slave_hosts)
+      end
+    end
+  end
+end
+
 describe Lhm::Throttler::SlaveLag do
   include UnitHelper
 
@@ -62,40 +152,50 @@ describe Lhm::Throttler::SlaveLag do
     end
   end
 
-  describe '#slave_hosts' do
+  describe '#get_slaves' do
     describe 'with no slaves' do
       before do
-        def @throttler.get_slaves
+        def @throttler.master_slave_hosts
           []
         end
       end
 
-      it 'returns no slave hosts' do
-        assert_equal([], @throttler.send(:slave_hosts))
+      it 'returns no slaves' do
+        assert_equal([], @throttler.send(:get_slaves))
       end
     end
 
-    describe 'with only localhost slaves' do
+    describe 'with multiple slaves' do
       before do
-        def @throttler.get_slaves
-          ['localhost:1234', '127.0.0.1:5678']
+        class TestSlave
+          attr_reader :host, :connection
+
+          def initialize(host, get_config)
+            @host = host
+            @connection = 'conn' if @host
+          end
+
+          def slave_hosts
+            if @host == '1.1.1.1'
+              ['1.1.1.2', '1.1.1.3']
+            else
+              nil
+            end
+          end
+        end
+
+        def @throttler.master_slave_hosts
+          ['1.1.1.1', '1.1.1.4']
         end
       end
 
-      it 'returns no slave hosts' do
-        assert_equal([], @throttler.send(:slave_hosts))
-      end
-    end
-
-    describe 'with only remote slaves' do
-      before do
-        def @throttler.get_slaves
-          ['server.example.com:1234', 'anotherserver.example.com']
+      it 'returns the slave instances' do
+        create_slave = lambda { |host, config|
+          TestSlave.new(host, config)
+        }
+        Lhm::Throttler::Slave.stub :new, create_slave do
+          assert_equal(["1.1.1.4", "1.1.1.1", "1.1.1.3", "1.1.1.2"], @throttler.send(:get_slaves).map(&:host))
         end
-      end
-
-      it 'returns remote slave hosts' do
-        assert_equal(['server.example.com', 'anotherserver.example.com'], @throttler.send(:slave_hosts))
       end
     end
   end


### PR DESCRIPTION
This is my slave lag throttler code as compared to soundcloud/lhm master (the `lhm-upstream` branch in this repo).  I've tested it quite a bit with Shopify.  There's some small changes we need to make there to use this (https://github.com/Shopify/shopify/pull/49019), but other than the `logger_params` change I needed to make in that PR, upstream lhm works just fine for us.

As I've mentioned, I'm not PRing this upstream because it explicitly uses the `Mysql2::Client`, whereas upstream "is compatible and continuously tested with MRI 2.0.x, 2.1.x, ActiveRecord 3.2.x and 4.x (mysql and mysql2 adapters)."  But we're more concerned with throttling slave lag than we are with getting this code upstream right now.

So I think the plan right now (pending review) is to merge the `lhm-upstream` branch, merge this, merge my Shopify PR (along with an updated gem ref) then start throttling some slave lag.

@camilo @arthurnn @jasonhl @shuhaowu 
