### PR TITLE
Create emoji friendly tables by default

### DIFF
--- a/bin/lhm-spec-grants.sh
+++ b/bin/lhm-spec-grants.sh
@@ -21,5 +21,5 @@ echo "show slave status \G" | slave
 echo "grant all privileges on *.* to ''@'localhost'" | master
 echo "grant all privileges on *.* to ''@'localhost'" | slave
 
-echo "create database lhm" | master
+echo "create database if not exists lhm" | master
 echo "create database if not exists lhm" | slave

--- a/bin/lhm-spec-setup-cluster.sh
+++ b/bin/lhm-spec-setup-cluster.sh
@@ -18,19 +18,25 @@ mkdir -p "$basedir/master/data" "$basedir/slave/data"
 
 cat <<-CNF > $basedir/master/my.cnf
 [mysqld]
+log-bin = master-bin
+log-bin-index = master-bin.index
+innodb_large_prefix = 1
+innodb_file_format = Barracuda
+innodb_file_per_table = 1
 pid-file = $basedir/master/mysqld.pid
 socket = $basedir/master/mysqld.sock
 port = $master_port
 log_output = FILE
 log-error = $basedir/master/error.log
 datadir = $basedir/master/data
-log-bin = master-bin
-log-bin-index = master-bin.index
 server-id = 1
 CNF
 
 cat <<-CNF > $basedir/slave/my.cnf
 [mysqld]
+innodb_large_prefix = 1
+innodb_file_format = Barracuda
+innodb_file_per_table = 1
 pid-file = $basedir/slave/mysqld.pid
 socket = $basedir/slave/mysqld.sock
 port = $slave_port

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -210,6 +210,7 @@ module Lhm
       original    = %{CREATE TABLE `#{ @origin.name }`}
       replacement = %{CREATE TABLE `#{ @origin.destination_name }`}
       stmt = @origin.ddl.gsub(original, replacement)
+        .gsub(/DEFAULT CHARSET=\w*/, "DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC")
       @connection.execute(tagged(stmt))
     end
 

--- a/spec/fixtures/no_charset.ddl
+++ b/spec/fixtures/no_charset.ddl
@@ -1,0 +1,4 @@
+CREATE TABLE `no_charset` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB

--- a/spec/fixtures/non_default_charset.ddl
+++ b/spec/fixtures/non_default_charset.ddl
@@ -1,0 +1,4 @@
+CREATE TABLE `non_default_charset` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB CHARSET=utf8

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -37,7 +37,7 @@ module IntegrationHelper
   def ar_conn(port)
     ActiveRecord::Base.establish_connection(
       :adapter  => defined?(Mysql2) ? 'mysql2' : 'mysql',
-      :host     => '127.0.0.1',
+      :host     => 'localhost',
       :database => 'lhm',
       :username => 'root',
       :port     => port,

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -352,17 +352,33 @@ describe Lhm do
           count_all(:users).must_equal(40)
         end
       end
+    end
 
-      it 'should create all tables with "DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"' do
+    describe "utf8mb4 support" do
+      def check_if_utf8mb4_enabled(table)
         options = { :stride => 10, :throttle => 97, :atomic_switch => false }
 
-        Lhm.change_table(:users, options) do |t|
+        Lhm.change_table(table, options) do |t|
           t.add_column(:emoji, "INT(10) DEFAULT '0'")
         end
 
         slave do
-          table_read(:users).ddl.must_include('ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC')
+          table_read(table).ddl.must_include('DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC')
         end
+      end
+
+      it 'should create tables with no charset with utf8mb4' do
+        table_create(:no_charset)
+        check_if_utf8mb4_enabled(:no_charset)
+      end
+
+      it 'should create tables with a charset with utf8mb4' do
+        table_create(:non_default_charset)
+        check_if_utf8mb4_enabled(:non_default_charset)
+      end
+
+      it 'should create tables with a default charset with utf8mb4' do
+        check_if_utf8mb4_enabled(:users)
       end
     end
   end

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -352,6 +352,18 @@ describe Lhm do
           count_all(:users).must_equal(40)
         end
       end
+
+      it 'should create all tables with "DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"' do
+        options = { :stride => 10, :throttle => 97, :atomic_switch => false }
+
+        Lhm.change_table(:users, options) do |t|
+          t.add_column(:emoji, "INT(10) DEFAULT '0'")
+        end
+
+        slave do
+          table_read(:users).ddl.must_include('ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This will patch LHM to create all tables with `DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC` by default.  As long as a table has an LHM run on it at some point, it'll now be emoji friendly without us having to manually update it.

The code is pretty simple.  Normally when creating the new table, LHM takes the existing table's attributes and simply swaps its name with `lhmn_#{name}`.  This adds a regex that'll also swap the `DEFAULT CHARSET=x` with `DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC`  

Getting the integration tests passing was a bit of a nightmare, but I've finally got everything passing locally. 

Proof (from the integration tests):

```
CREATE TABLE `lhmn_users` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `reference` int(11) DEFAULT NULL,
  `username` varchar(255) DEFAULT NULL,
  `group` varchar(255) DEFAULT 'Superfriends',
  `created_at` datetime DEFAULT NULL,
  `comment` varchar(20) DEFAULT NULL,
  `description` text,
  PRIMARY KEY (`id`),
  UNIQUE KEY `index_users_on_reference` (`reference`),
  KEY `index_users_on_username_and_created_at` (`username`,`created_at`),
  KEY `index_with_a_custom_name` (`username`,`group`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC /* large hadron migration */
```
@SingerWang @jasonhl 