### PR TITLE
Rescue failed connections on slave lag check, return 0

### DIFF
--- a/bin/lhm-spec-grants.sh
+++ b/bin/lhm-spec-grants.sh
@@ -21,5 +21,5 @@ echo "show slave status \G" | slave
 echo "grant all privileges on *.* to ''@'localhost'" | master
 echo "grant all privileges on *.* to ''@'localhost'" | slave
 
-echo "create database lhm" | master
+echo "create database if not exists lhm" | master
 echo "create database if not exists lhm" | slave

--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -114,8 +114,9 @@ module Lhm
       def query_connection(query, result)
         begin
           @connection.query(query).map { |row| row[result] }
-        rescue Error => e
-          raise Lhm::Error, "Unable to connect and/or query slave to determine slave lag. Migration aborting because of: #{e}"
+        rescue Exception => e
+          Lhm.logger.info "Unable to connect and/or query #{host}: #{e}"
+          0
         end
       end
     end

--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -68,7 +68,7 @@ module Lhm
       end
 
       def max_current_slave_lag
-        max = slaves.map { |slave| slave.lag }.flatten.push(0).max
+        max = slaves.map { |slave| slave.lag }.push(0).max
         Lhm.logger.info "Max current slave lag: #{max}"
         max
       end
@@ -90,7 +90,7 @@ module Lhm
       end
 
       def lag
-        query_connection(SQL_SELECT_MAX_SLAVE_LAG, 'Seconds_Behind_Master')
+        query_connection(SQL_SELECT_MAX_SLAVE_LAG, 'Seconds_Behind_Master').first.to_i
       end
 
       private
@@ -114,7 +114,7 @@ module Lhm
       def query_connection(query, result)
         begin
           @connection.query(query).map { |row| row[result] }
-        rescue Exception => e
+        rescue Mysql2::Error => e
           Lhm.logger.info "Unable to connect and/or query #{host}: #{e}"
           0
         end

--- a/spec/README.md
+++ b/spec/README.md
@@ -43,7 +43,7 @@ Follow the manual instructions if you want more control over this process.
 
 Setup the dependency gems
 
-    export BUNDLE_GEMFILE=gemfiles/ar-3.2_mysql2.gemfile
+    export BUNDLE_GEMFILE=gemfiles/ar-4.2_mysql2.gemfile
     bundle install
 
 To run specs in slave mode, set the MASTER_SLAVE=1 when running tests:

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -70,6 +70,8 @@ describe Lhm::Throttler::Slave do
             [{'Seconds_Behind_Master' => 20}]
           elsif query == Lhm::Throttler::Slave::SQL_SELECT_SLAVE_HOSTS
             [{'host' => '1.1.1.1:80'}]
+          elsif query == 'foo'
+            raise Mysql2::Error.new('error')
           end
         end
       end
@@ -87,6 +89,14 @@ describe Lhm::Throttler::Slave do
     describe "#slave_hosts" do
       it "returns the hosts" do
         assert_equal(['1.1.1.1'], @slave.slave_hosts)
+      end
+    end
+
+    describe "#lag on connection error" do
+      it "returns 0" do
+        result = @slave.send(:query_connection, 'foo', 'bar')
+        assert_send([Lhm.logger, :info, "Unable to connect and/or query slave: error"])
+        assert_equal(0, result)
       end
     end
   end

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -78,11 +78,26 @@ describe Lhm::Throttler::Slave do
 
       @slave = Lhm::Throttler::Slave.new('slave', get_config)
       @slave.instance_variable_set(:@connection, Connection)
+
+      class StoppedConnection
+        def self.query(query)
+          [{'Seconds_Behind_Master' => nil}]
+        end
+      end
+
+      @stopped_slave = Lhm::Throttler::Slave.new('stopped_slave', get_config)
+      @stopped_slave.instance_variable_set(:@connection, StoppedConnection)
     end
 
     describe "#lag" do
       it "returns the slave lag" do
-        assert_equal([20], @slave.lag)
+        assert_equal(20, @slave.lag)
+      end
+    end
+
+    describe "#lag with a stopped slave" do
+      it "returns 0 slave lag" do
+        assert_equal(0, @stopped_slave.lag)
       end
     end
 


### PR DESCRIPTION
We've been intentionally raising here when you can't connect to a slave to check its lag during an LHM.  Which made sense... except we have servers that we know have some I/O issues and are lagging all the time, slowing down LHMs, and we'd like to be able to stop those.  Or if a reader simply dies or something... if that happens right now after you're 20 hours into an LHM then the whole thing blows up with an exception, and you have to start all over again.

This PR will change that.  So instead of raising, if we can't query a server to check it's lag, we'll simply log and pretend there is no lag.  If the server comes back up, it'll just be checked again the next time we can connect to it.

The code is pretty straightforward - I haven't 🎩  in production, but I feel like the safest course of action is not to run a dummy LHM in production... rather we should just merge this PR, update Shopify core to use it, run a real LHM, disconnect some slaves and watch the LHM keep running.

@sroysen @jasonhl 