### PR TITLE
Optionally throttle based on the lag of a single slave

### DIFF
--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -52,7 +52,7 @@ module Lhm
 
       def get_slaves
         slaves = []
-        if @check_only.nil?
+        if @check_only.nil? or !@check_only.respond_to?(:call)
           slave_hosts = master_slave_hosts
           while slave_hosts.any? do
             host = slave_hosts.pop

--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -23,6 +23,7 @@ module Lhm
         @allowed_lag = options[:allowed_lag] || DEFAULT_MAX_ALLOWED_LAG
         @slaves = {}
         @get_config = options[:current_config]
+        @check_only = options[:check_only]
       end
 
       def execute
@@ -51,14 +52,19 @@ module Lhm
 
       def get_slaves
         slaves = []
-        slave_hosts = master_slave_hosts
-        while slave_hosts.any? do
-          host = slave_hosts.pop
-          slave = Slave.new(host, @get_config)
-          if slaves.map(&:host).exclude?(host) && slave.connection
-            slaves << slave
-            slave_hosts.concat(slave.slave_hosts)
+        if @check_only.nil?
+          slave_hosts = master_slave_hosts
+          while slave_hosts.any? do
+            host = slave_hosts.pop
+            slave = Slave.new(host, @get_config)
+            if slaves.map(&:host).exclude?(host) && slave.connection
+              slaves << slave
+              slave_hosts.concat(slave.slave_hosts)
+            end
           end
+        else
+          slave_config = @check_only.call
+          slaves << Slave.new(slave_config['host'], @get_config)
         end
         slaves
       end

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -209,17 +209,35 @@ describe Lhm::Throttler::SlaveLag do
           end
         end
 
-        def @throttler.master_slave_hosts
-          ['1.1.1.1', '1.1.1.4']
+        @create_slave = lambda { |host, config|
+          TestSlave.new(host, config)
+        }
+      end
+
+      describe 'without the :check_only option' do
+        before do
+          def @throttler.master_slave_hosts
+            ['1.1.1.1', '1.1.1.4']
+          end
+        end
+
+        it 'returns the slave instances' do
+          Lhm::Throttler::Slave.stub :new, @create_slave do
+            assert_equal(["1.1.1.4", "1.1.1.1", "1.1.1.3", "1.1.1.2"], @throttler.send(:get_slaves).map(&:host))
+          end
         end
       end
 
-      it 'returns the slave instances' do
-        create_slave = lambda { |host, config|
-          TestSlave.new(host, config)
-        }
-        Lhm::Throttler::Slave.stub :new, create_slave do
-          assert_equal(["1.1.1.4", "1.1.1.1", "1.1.1.3", "1.1.1.2"], @throttler.send(:get_slaves).map(&:host))
+      describe 'with the :check_only option' do
+        before do
+          check_only = lambda {{'host' => '1.1.1.3'}}
+          @throttler = Lhm::Throttler::SlaveLag.new :check_only => check_only
+        end
+
+        it 'returns only that single slave' do
+          Lhm::Throttler::Slave.stub :new, @create_slave do
+            assert_equal ['1.1.1.3'], @throttler.send(:get_slaves).map(&:host)
+          end
         end
       end
     end


### PR DESCRIPTION
New option `:check_only` expects a lambda returning a connection config fragment for the specific slave; however, beware that credentials for the master are use to connect to this slave.

R: @sroysen, @jordanwheeler.
