### PR TITLE
Retry triggers on timeout exceeded error

### DIFF
--- a/bin/lhm-spec-grants.sh
+++ b/bin/lhm-spec-grants.sh
@@ -7,11 +7,12 @@ slave()  { "$mysqldir"/bin/mysql --protocol=TCP -P $slave_port -uroot; }
 
 # set up master
 
-echo "create user 'slave'@'localhost' identified by 'slave'" | master
+echo "create user if not exists 'slave'@'localhost' identified by 'slave'" | master
 echo "grant replication slave on *.* to 'slave'@'localhost'" | master
 
 # set up slave
 
+echo "stop slave" | slave
 echo "change master to master_user = 'slave', master_password = 'slave', master_port = $master_port, master_host = 'localhost'" | slave
 echo "start slave" | slave
 echo "show slave status \G" | slave

--- a/bin/lhm-spec-grants.sh
+++ b/bin/lhm-spec-grants.sh
@@ -7,7 +7,7 @@ slave()  { "$mysqldir"/bin/mysql --protocol=TCP -P $slave_port -uroot; }
 
 # set up master
 
-echo "create user if not exists 'slave'@'localhost' identified by 'slave'" | master
+echo "create user 'slave'@'localhost' identified by 'slave'" | master
 echo "grant replication slave on *.* to 'slave'@'localhost'" | master
 
 # set up slave

--- a/lhm.gemspec
+++ b/lhm.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = ['lhm-kill-queue']
 
   s.add_development_dependency 'minitest'
+  s.add_development_dependency 'mocha'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'activerecord'
   s.add_development_dependency 'mysql'

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -42,7 +42,7 @@ module Lhm
       set_session_lock_wait_timeouts
       migration = @migrator.run
 
-      Entangler.new(migration, @connection).run do
+      Entangler.new(migration, @connection, options).run do
         Chunker.new(migration, @connection, options).run
         if options[:atomic_switch]
           AtomicSwitcher.new(migration, @connection).run

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -4,6 +4,7 @@
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'minitest/mock'
+require 'mocha/mini_test'
 require 'pathname'
 require 'lhm'
 


### PR DESCRIPTION
We've had a bunch of failed LHMs lately because of deadlocks creating/deleting the triggers.  It's especially frustrating when the whole thing runs, then it tries once to delete the triggers, times out after 8 seconds, and fails.  So then we have to restart the whole thing.

This puts the trigger creation/deletion in a retry block, so if the lock wait timeout is exceeded, the LHM will log, wait 1 second, and then try again. 10 times.  We chose 1 second of sleep and 10 retries to mimic PTOSC's behaviour - it never seems to have this problem.

I kind of tested it with an LHM locally, and the test may look kind of weird but it works as expected.

@insom @sroysen 
