### PR TITLE
Handle checking slave lag when mysql is stopped

### DIFF
--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -122,7 +122,7 @@ module Lhm
           @connection.query(query).map { |row| row[result] }
         rescue Mysql2::Error => e
           Lhm.logger.info "Unable to connect and/or query #{host}: #{e}"
-          0
+          [nil]
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/Shopify/lhm/issues/16

In https://github.com/Shopify/lhm/pull/13 I ended up trying to fix a couple different things.  That did fix the case where we "stop slave" on a running node in the chain, but it broke in the case where we stop MySQL altogether on a slave.

One of the tests I added there was not very good, because it tested the outcome of a private method that I changed.  Had it tested the actual `lag` method that we care about, it would have caught the bug.  I updated that test, and added another regression test that catches the specific exception we saw in production.

@sroysen @insom 