### PR TITLE
add a test for max_current_slave_lag with multiple slaves

### DIFF
--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -181,6 +181,17 @@ describe Lhm::Throttler::SlaveLag do
   end
 
   describe '#max_current_slave_lag' do
+    describe 'with multiple slaves' do
+      it 'returns the largest amount of lag' do
+        slave1 = mock()
+        slave2 = mock()
+        slave1.stubs(:lag).returns(5)
+        slave2.stubs(:lag).returns(0)
+        Lhm::Throttler::SlaveLag.any_instance.stubs(:slaves).returns([slave1, slave2])
+        assert_equal 5, @throttler.send(:max_current_slave_lag)
+      end
+    end
+
     describe 'with MySQL stopped on the slave' do
       it 'assumes 0 slave lag' do
         client = mock()


### PR DESCRIPTION
@insom i wrote this test earlier as a sanity check.  it passes.  so i think our problem is a connection to slaves issue, not necessarily a code issue.

anyways, i realized there wasn't a great test covering this logic specifically, so i figured i might as well add it to master.