### PR TITLE
use kafka logger when available

### DIFF
--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -55,6 +55,7 @@ module Lhm
     private
 
     def normalize_options(options)
+      Lhm.logger = options[:kafka_logger] if options[:kafka_logger]
       Lhm.logger.info "Starting LHM run on table=#{@migrator.name}"
 
       unless options.include?(:atomic_switch)


### PR DESCRIPTION
@shuhaowu @insom 

This will tell LHM to use the kafka_logger passed in from https://github.com/Shopify/shopify/pull/106355

Tested locally and it passes the params to `KafkaShopify` as expected.  Will have to wait until it's live to see it actually logging to kafka though.