### PR TITLE
Add activerecord 5.0 gemfile, update tests, fix deprecation warning

### DIFF
--- a/gemfiles/ar-5.0_mysql2.gemfile
+++ b/gemfiles/ar-5.0_mysql2.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "mysql2", "~> 0.4.5"
+gem "activerecord", "~> 5.0.2"
+gemspec :path=>"../"

--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -41,8 +41,8 @@ module Lhm
     end
 
     def validate
-      unless @connection.table_exists?(@origin.name) &&
-             @connection.table_exists?(@destination.name)
+      unless @connection.data_source_exists?(@origin.name) &&
+             @connection.data_source_exists?(@destination.name)
         error "`#{ @origin.name }` and `#{ @destination.name }` must exist"
       end
     end

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -73,11 +73,11 @@ module Lhm
     end
 
     def validate
-      unless @connection.table_exists?(@origin.name)
+      unless @connection.data_source_exists?(@origin.name)
         error("#{ @origin.name } does not exist")
       end
 
-      unless @connection.table_exists?(@destination.name)
+      unless @connection.data_source_exists?(@destination.name)
         error("#{ @destination.name } does not exist")
       end
     end

--- a/lib/lhm/locked_switcher.rb
+++ b/lib/lhm/locked_switcher.rb
@@ -53,8 +53,8 @@ module Lhm
     end
 
     def validate
-      unless @connection.table_exists?(@origin.name) &&
-             @connection.table_exists?(@destination.name)
+      unless @connection.data_source_exists?(@origin.name) &&
+             @connection.data_source_exists?(@destination.name)
         error "`#{ @origin.name }` and `#{ @destination.name }` must exist"
       end
     end

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -183,7 +183,7 @@ module Lhm
     private
 
     def validate
-      unless @connection.table_exists?(@origin.name)
+      unless @connection.data_source_exists?(@origin.name)
         error("could not find origin table #{ @origin.name }")
       end
 
@@ -193,7 +193,7 @@ module Lhm
 
       dest = @origin.destination_name
 
-      if @connection.table_exists?(dest)
+      if @connection.data_source_exists?(dest)
         error("#{ dest } should not exist; not cleaned up from previous run?")
       end
     end

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -31,7 +31,7 @@ describe Lhm::AtomicSwitcher do
       skip 'This spec only works with mysql2' unless defined? Mysql2
 
         connection = mock()
-        connection.stubs(:table_exists?).returns(true)
+        connection.stubs(:data_source_exists?).returns(true)
         connection.stubs(:execute).raises(ActiveRecord::StatementInvalid, 'Lock wait timeout exceeded; try restarting transaction.').then.returns(true)
 
         switcher = Lhm::AtomicSwitcher.new(@migration, connection)
@@ -43,7 +43,7 @@ describe Lhm::AtomicSwitcher do
     it 'should give up on lock wait timeouts after MAX_RETRIES' do
       skip 'This spec only works with mysql2' unless defined? Mysql2
         connection = mock()
-        connection.stubs(:table_exists?).returns(true)
+        connection.stubs(:data_source_exists?).returns(true)
         connection.stubs(:execute).twice.raises(ActiveRecord::StatementInvalid, 'Lock wait timeout exceeded; try restarting transaction.')
 
         switcher = Lhm::AtomicSwitcher.new(@migration, connection)
@@ -66,7 +66,7 @@ describe Lhm::AtomicSwitcher do
       switcher.run
 
       slave do
-        table_exists?(@origin).must_equal true
+        data_source_exists?(@origin).must_equal true
         table_read(@migration.archive_name).columns.keys.must_include 'origin'
       end
     end
@@ -76,7 +76,7 @@ describe Lhm::AtomicSwitcher do
       switcher.run
 
       slave do
-        table_exists?(@destination).must_equal false
+        data_source_exists?(@destination).must_equal false
         table_read(@origin.name).columns.keys.must_include 'destination'
       end
     end

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -71,9 +71,9 @@ describe Lhm::Chunker do
     it 'should throttle work stride based on slave lag' do
       5.times { |n| execute("insert into origin set id = '#{ (n * n) + 1 }'") }
 
-      printer = MiniTest::Mock.new
-      15.times { printer.expect(:notify, :return_value, [Fixnum, Fixnum]) }
-      printer.expect(:end, :return_value, [])
+      printer = mock()
+      printer.expects(:notify).with(instance_of(Fixnum), instance_of(Fixnum)).twice
+      printer.expects(:end)
 
       throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0)
       def throttler.max_current_slave_lag
@@ -89,16 +89,15 @@ describe Lhm::Chunker do
       slave do
         count_all(@destination.name).must_equal(5)
       end
-
-      printer.verify
     end
 
     it 'should detect a single slave with no lag in the default configuration' do
       5.times { |n| execute("insert into origin set id = '#{ (n * n) + 1 }'") }
 
-      printer = MiniTest::Mock.new
-      15.times { printer.expect(:notify, :return_value, [Fixnum, Fixnum]) }
-      printer.expect(:end, :return_value, [])
+      printer = mock()
+      printer.expects(:notify).with(instance_of(Fixnum), instance_of(Fixnum)).twice
+      printer.expects(:verify)
+      printer.expects(:end)
 
       throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0)
 

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -121,8 +121,8 @@ module IntegrationHelper
     Lhm::Table.parse(fixture_name, @connection)
   end
 
-  def table_exists?(table)
-    connection.table_exists?(table.name)
+  def data_source_exists?(table)
+    connection.data_source_exists?(table.name)
   end
 
   #

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -119,7 +119,7 @@ describe Lhm do
       end
 
       slave do
-        table_read(:users).columns['comment'].must_equal nil
+        assert_nil table_read(:users).columns['comment']
       end
     end
 

--- a/spec/integration/locked_switcher_spec.rb
+++ b/spec/integration/locked_switcher_spec.rb
@@ -32,7 +32,7 @@ describe Lhm::LockedSwitcher do
       switcher.run
 
       slave do
-        table_exists?(@origin).must_equal true
+        data_source_exists?(@origin).must_equal true
         table_read(@migration.archive_name).columns.keys.must_include 'origin'
       end
     end
@@ -42,7 +42,7 @@ describe Lhm::LockedSwitcher do
       switcher.run
 
       slave do
-        table_exists?(@destination).must_equal false
+        data_source_exists?(@destination).must_equal false
         table_read(@origin.name).columns.keys.must_include 'destination'
       end
     end

--- a/spec/integration/table_spec.rb
+++ b/spec/integration/table_spec.rb
@@ -72,7 +72,7 @@ describe Lhm::Table do
       end
 
       it 'should parse column metadata' do
-        @table.columns['username'][:column_default].must_equal nil
+        assert_nil @table.columns['username'][:column_default]
       end
 
       it 'should parse indices' do

--- a/spec/unit/printer_spec.rb
+++ b/spec/unit/printer_spec.rb
@@ -26,25 +26,28 @@ describe Lhm::Printer do
       mock.verify
     end
 
-    it 'always print a bigger message' do
+    it 'always prints a bigger message' do
       @length = 0
-      mock = MiniTest::Mock.new
-      3.times do
-        mock.expect(:write, :return_value) do |message|
-          message = message.first if message.is_a?(Array)
-          assert message.length >= @length
-          @length = message.length
-        end
+      printer_mock = mock()
+      printer_mock.expects(:write).at_least_once
+
+      def assert_length(printer)
+        new_length = printer.instance_variable_get(:@max_length)
+        assert new_length >= @length
+        @length = new_length
       end
 
-      @printer.instance_variable_set(:@output, mock)
+      @printer.instance_variable_set(:@output, printer_mock)
       @printer.notify(10, 100)
+      assert_length(@printer)
       @printer.notify(0, 100)
+      assert_length(@printer)
       @printer.notify(1, 1000000)
+      assert_length(@printer)
       @printer.notify(0, 0)
+      assert_length(@printer)
       @printer.notify(0, nil)
-
-      mock.verify
+      assert_length(@printer)
     end
 
     it 'prints the end message' do

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -43,7 +43,7 @@ describe Lhm::Throttler::Slave do
         test_client = lambda { |config|
           TestMysql2Client.new(config)
         }
-        Mysql2::Client.stub :new, test_client do
+        Mysql2::Client.stubs(:new).returns(test_client) do
           assert_send([Lhm.logger, :info, "Error connecting to slave: connection error"])
           assert_nil(Lhm::Throttler::Slave.new('slave', lambda { {} }).connection)
         end
@@ -55,7 +55,7 @@ describe Lhm::Throttler::Slave do
         client_assertion = lambda { |config|
           assert_equal(config, {'username' => 'user', 'password' => 'pw', 'database' => 'db', 'host' => 'slave'})
         }
-        Mysql2::Client.stub :new, client_assertion do
+        Mysql2::Client.stubs(:new).returns(client_assertion) do
           Lhm::Throttler::Slave.new('slave', get_config)
         end
       end
@@ -252,7 +252,7 @@ describe Lhm::Throttler::SlaveLag do
         end
 
         it 'returns the slave instances' do
-          Lhm::Throttler::Slave.stub :new, @create_slave do
+          Lhm::Throttler::Slave.stubs(:new).returns(@create_slave) do
             assert_equal(["1.1.1.4", "1.1.1.1", "1.1.1.3", "1.1.1.2"], @throttler.send(:get_slaves).map(&:host))
           end
         end
@@ -266,7 +266,7 @@ describe Lhm::Throttler::SlaveLag do
           end
 
           it 'returns only that single slave' do
-            Lhm::Throttler::Slave.stub :new, @create_slave do
+            Lhm::Throttler::Slave.stubs(:new).returns(@create_slave) do
               assert_equal ['1.1.1.3'], @throttler.send(:get_slaves).map(&:host)
             end
           end
@@ -281,7 +281,7 @@ describe Lhm::Throttler::SlaveLag do
           end
 
           it 'returns all the slave instances' do
-            Lhm::Throttler::Slave.stub :new, @create_slave do
+            Lhm::Throttler::Slave.stubs(:new).returns(@create_slave) do
               assert_equal(["1.1.1.4", "1.1.1.1", "1.1.1.3", "1.1.1.2"], @throttler.send(:get_slaves).map(&:host))
             end
           end


### PR DESCRIPTION
I added an activerecord 5.0 gemfile, with the newer version of mysql2, which matches what we run in Shopify core.  All the tests now pass both here, and with the previous version of the Gemfile.  Nothing changed functionality wise, I basically just changed a bunch of stubbing stuff and simplified some of the tests as I went.  No actual code was touched.  But I didn't want to merge without at least opening a PR first 😄   You can try running the tests yourself if you want.

@sroysen @insom 

