### PR TITLE
handle nil host in formatted_hosts

### DIFF
--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -2,8 +2,13 @@ module Lhm
   module Throttler
 
     def self.format_hosts(hosts)
-      hosts.map { |host| host.partition(':')[0] }
-        .delete_if { |host| host == 'localhost' || host == '127.0.0.1' }
+      formatted_hosts = []
+      hosts.each do |host|
+        if host && !host.match(/localhost/) && !host.match(/127.0.0.1/)
+          formatted_hosts << host.partition(':')[0]
+        end
+      end
+      formatted_hosts
     end
 
     class SlaveLag

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -17,6 +17,18 @@ describe Lhm::Throttler do
         assert_equal(['server.example.com', 'anotherserver.example.com'], Lhm::Throttler.format_hosts(['server.example.com:1234', 'anotherserver.example.com']))
       end
     end
+
+    describe 'with only nil hosts' do
+      it 'returns no hosts' do
+        assert_equal([], Lhm::Throttler.format_hosts([nil]))
+      end
+    end
+
+    describe 'with some nil hosts' do
+      it 'returns the remaining hosts' do
+        assert_equal(['server.example.com'], Lhm::Throttler.format_hosts([nil, 'server.example.com:1234']))
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This will fix the `undefined method partition for nil:NilClass` error.  Now that `query_connection` returns a nil when it can't connect to the host, we need to handle that in the `format_hosts` method too.

@insom @sroysen