### PR TITLE
Fix the potential of a by one error in the chunker

### DIFF
--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -27,7 +27,7 @@ module Lhm
     def execute
       return unless @start && @limit
       @next_to_insert = @start
-      while @next_to_insert < @limit || (@start == @limit)
+      while @next_to_insert <= @limit || (@start == @limit)
         stride = @throttler.stride
         affected_rows = @connection.update(copy(bottom, top(stride)))
 


### PR DESCRIPTION
I am going to push this PR now, but I am probably not going to merge it: before the end of the week we need to come with a better way to decide the lower and upper boundaries of a chunk: A fixed upper boundary calculated as `lower boundary + stride` is not going to work in our environment.

On one side, we have widely different values of auto_increment_increment in several shards (64 in the majority, and 32k in the new ones).

At the same time, the lower sections of a table are going to have primary keys that are going to be really close to one another, coming from the pre-sharding times where we just used the default auto_increment_increment value of `1`.

Then, we are going to have records with a space of 4 primary keys between them (from when we have auto_increment_increment = 4).
Then, spaces of 64 primary keys between records.
And now, 32K.

The point is that we cannot just simply try to use a bigger stride that is going to allow us to grab enough records for the 32k case: if we do that, then for the first section of each table we are likely going to grab several million records in each chunk.

@jordanwheeler 

/CC @camilo, since we were talking about this earlier today.
