### PR TITLE
Change LHMs to use a non-fixed copy window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ spec/integration/database.yml
 Gemfile
 gemfiles/vendor
 omg.ponies
+*~

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -232,7 +232,7 @@ describe Lhm do
         table_read(:small_table).columns['id'].must_equal({
           :type => 'int(5)',
           :is_nullable => 'NO',
-          :column_default => '0',
+          :column_default => nil,
         })
       end
     end
@@ -376,7 +376,7 @@ describe Lhm do
 
         delete = Thread.new do
           10.times do |n|
-            execute("delete from users where id = '#{ n + 1 }'")
+            execute("delete from users where reference = '#{ n }'")
             sleep(0.17)
           end
         end


### PR DESCRIPTION
This LHM will radically change the way that chunks of records are grabbed from the source table to be copied to the destination table.

Right now, LHMs work by copying fixed sets of primary keys, where the definition for the top id to copy in each chunk is simply the addition of the stride to the lower id of the chunk.

That has always been inefficient, even on tables using all mysql defaults (meaning, auto_increment_increment value of 1: primary keys grow just one by one), for several reasons:

1. Usual write patterns on any table are going to leave holes in them (when deleting records). 
With a fixed window of primary keys as before, LHMs were going to run ignorant of the real distribution of records in a table.
2. Gaps of primary keys in a table for any reason (for instance the insertion of a single record with a high value of id) would render LHM as a useless tool, since the run, even if the table has only two records (id values of 1 and 223372036854775808, a feasible value when using bigint for the primary key) was literally going to take years.
3. Sharded environments using  values of auto_increment_increment  > 1,  would see that each chunk was going to have less and less records in it. To an extreme where if the stride was lower than the auto_increment_increment value, chunks were actually going to be empty.

The change in this PR will identify the value of the max primary key to use in each chunk, and it will use that value for the `id between.....` clause.
It will then start the next chunk starting at plus one of the last record copied.

The changes in this PR will also fix the issue of potential data loss when the first record of the last chunk to be copied by the chunker was going to coincide with the upper limit initially identified by the chunker (an issue described in [this PR](https://github.com/Shopify/lhm/pull/25)

Additional changes: I extended the usage of a local database.yml in order to allow integrations tests to run in virtually any type of pairs of `master-slave` mysql instances, not only local ones.

