### PR TITLE
Reduce the size of the default chunk to 2K

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ to prevent accidental data loss.
 
 Lhm is using a throttle mechanism to read data in your original table.
 
-By default, 40000 rows are read each 0.1 second.
+By default, 2000 rows are read each 0.1 second.
 
 If you want to change that behaviour, you can pass an instance of a throttler with the `throttler` option.
 

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -28,7 +28,7 @@ module Lhm
   # @param [String, Symbol] table_name Name of the table
   # @param [Hash] options Optional options to alter the chunk / switch behavior
   # @option options [Fixnum] :stride
-  #   Size of a chunk (defaults to: 40,000)
+  #   Size of a chunk (defaults to: 2,000)
   # @option options [Fixnum] :throttle
   #   Time to wait between chunks in milliseconds (defaults to: 100)
   # @option options [Fixnum] :start

--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -15,7 +15,7 @@ module Lhm
       include Command
 
       INITIAL_TIMEOUT = 0.1
-      DEFAULT_STRIDE = 40_000
+      DEFAULT_STRIDE = 2_000
       DEFAULT_MAX_ALLOWED_LAG = 10
 
       MAX_TIMEOUT = INITIAL_TIMEOUT * 1024

--- a/lib/lhm/throttler/time.rb
+++ b/lib/lhm/throttler/time.rb
@@ -4,7 +4,7 @@ module Lhm
       include Command
 
       DEFAULT_TIMEOUT = 0.1
-      DEFAULT_STRIDE = 40_000
+      DEFAULT_STRIDE = 2_000
 
       attr_accessor :timeout_seconds
       attr_accessor :stride


### PR DESCRIPTION
As the title says: Reduces the default size of a chunk to a more reasonable 2K.

