### PR TITLE
The command is actually `Binlog Dump GTID` on GTID servers

### DIFF
--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -86,7 +86,7 @@ module Lhm
     end
 
     class Slave
-      SQL_SELECT_SLAVE_HOSTS = "SELECT host FROM information_schema.processlist WHERE command='Binlog Dump'"
+      SQL_SELECT_SLAVE_HOSTS = "SELECT host FROM information_schema.processlist WHERE command LIKE 'Binlog Dump%'"
       SQL_SELECT_MAX_SLAVE_LAG = 'SHOW SLAVE STATUS'
 
       attr_reader :host, :connection


### PR DESCRIPTION
The original query didn't match anything on the cloud nodes, as they show `Binlog Dump GTID` in the process list. I just made it a wildcard instead.