### PR TITLE
Preparation for PackageCloud

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in shopify_lhm.gemspec
+gemspec
+
+group :deployment do
+  gem 'package_cloud'
+  gem 'rake'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'rake/testtask'
 require 'bundler'
+require 'bundler/gem_tasks'
 
 Bundler::GemHelper.install_tasks
 

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,0 +1,4 @@
+deploy:
+  override:
+    - bundle exec rake build
+    - bundle exec package_cloud push shopify/gems pkg/*.gem


### PR DESCRIPTION
I had to add a Gemfile, which was previously in `.gitignore`. We're getting further away from something we can merge back into soundcloud/lhm so I'm not sure if this is a good idea.

After this I'll

- create a shipit stack
- create a github release for version 3.0.0.alpha
- deploy a build to packagecloud via shipit
