### PR TITLE
Fix dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.gem
 .bundle
-Gemfile.lock
 gemfiles/*.lock
 pkg/*
 .rvmrc

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,3 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in shopify_lhm.gemspec
 gemspec
 
-group :deployment do
-  gem 'package_cloud'
-  gem 'rake'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,73 @@
+PATH
+  remote: .
+  specs:
+    lhm (3.0.0.alpha)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (5.2.0)
+      activesupport (= 5.2.0)
+    activerecord (5.2.0)
+      activemodel (= 5.2.0)
+      activesupport (= 5.2.0)
+      arel (>= 9.0)
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    arel (9.0.0)
+    concurrent-ruby (1.0.5)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
+    highline (1.6.20)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
+    json_pure (1.8.1)
+    metaclass (0.0.4)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    minitest (5.11.3)
+    mocha (1.5.0)
+      metaclass (~> 0.0.1)
+    mysql2 (0.5.2)
+    netrc (0.11.0)
+    package_cloud (0.3.05)
+      highline (= 1.6.20)
+      json_pure (= 1.8.1)
+      rainbow (= 2.2.2)
+      rest-client (~> 2.0)
+      thor (~> 0.18)
+    rainbow (2.2.2)
+      rake
+    rake (12.3.1)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    thor (0.20.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord
+  lhm!
+  minitest
+  mocha
+  mysql2
+  package_cloud
+  rake
+
+BUNDLED WITH
+   1.16.1

--- a/lhm.gemspec
+++ b/lhm.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'activerecord'
-  s.add_development_dependency 'mysql'
+  s.add_development_dependency 'mysql2'
+  s.add_development_dependency 'package_cloud'
 end


### PR DESCRIPTION
* Do not specify dependencies in Gemfile (this is a gem)
  * rake was already in gemspec causing bundler to complain
  * added package_cloud to gemspec
* Change `mysql` to `mysql2` because `mysql` is so ancient it won't even compile
* Add Gemfile.lock - this is now considered best practice: https://github.com/bundler/bundler/pull/6184