### PR TITLE
Bring atomic_switch_spec code coverage to 100%

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
       tzinfo (~> 1.1)
     arel (9.0.0)
     concurrent-ruby (1.0.5)
+    docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     highline (1.6.20)
@@ -26,6 +27,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    json (2.1.0)
     json_pure (1.8.1)
     metaclass (0.0.4)
     mime-types (3.1)
@@ -49,6 +51,11 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -68,6 +75,7 @@ DEPENDENCIES
   mysql2
   package_cloud
   rake
+  simplecov
 
 BUNDLED WITH
    1.16.1

--- a/README.md
+++ b/README.md
@@ -229,6 +229,21 @@ dev int # integration tests
 dev test # all tests
 ```
 
+You can run an individual test as follows:
+```
+bundle exec rake unit TEST=spec/integration/atomic_switcher_spec.rb
+```
+
+You can get code coverage reporting for an individual test as follows:
+```
+rm -rf coverage; COV=1 bundle exec rake unit TEST=spec/integration/atomic_switcher_spec.rb; open coverage/index.html # test one file
+```
+
+or get code coverage for all tests:
+```
+dev cov
+```
+
 ### dbdeployer
 The integration tests rely on a master/slave replication setup of MySQL.
 We're using [dbdeployer](https://github.com/datacharmer/dbdeployer) to set this up via `./dbdeployer/install.sh`.

--- a/dev.yml
+++ b/dev.yml
@@ -16,3 +16,4 @@ commands:
   unit: bundle exec rake unit
   int: bundle exec rake integration
   test: bundle exec rake unit && bundle exec rake integration
+  cov: rm -rf coverage; COV=1 bundle exec rake unit && bundle exec rake integration; open coverage/index.html

--- a/lhm.gemspec
+++ b/lhm.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'activerecord'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'package_cloud'
+  s.add_development_dependency 'simplecov'
 end

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -55,8 +55,8 @@ describe Lhm::AtomicSwitcher do
 
     it 'should raise on non lock wait timeout exceptions' do
       switcher = Lhm::AtomicSwitcher.new(@migration, connection)
-      switcher.send :define_singleton_method, :statements do
-        ['SELECT', '*', 'FROM', 'nonexistent']
+      switcher.send :define_singleton_method, :atomic_switch do
+        'SELECT * FROM nonexistent'
       end
       -> { switcher.run }.must_raise(ActiveRecord::StatementInvalid)
     end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,6 +1,11 @@
 # Copyright (c) 2011 - 2013, SoundCloud Ltd., Rany Keddo, Tobias Bielohlawek, Tobias
 # Schmidt
 
+if ENV['COV']
+  require 'simplecov'
+  SimpleCov.start
+end
+
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'minitest/mock'

--- a/spec/unit/atomic_switcher_spec.rb
+++ b/spec/unit/atomic_switcher_spec.rb
@@ -21,11 +21,11 @@ describe Lhm::AtomicSwitcher do
   describe 'atomic switch' do
     it 'should perform a single atomic rename' do
       @switcher.
-        statements.
-        must_equal([
+        atomic_switch.
+        must_equal(
           "rename table `origin` to `#{ @migration.archive_name }`, " \
           '`destination` to `origin`'
-        ])
+        )
     end
   end
 end


### PR DESCRIPTION
I am considering refactoring the atomic_switch's
retry behavior. Before doing so, let's make sure we
have great test coverage everywhere. This adds
some tools to make that happen and adds test
coverage.