### PR TITLE
Address some deprecation warnings

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -27,13 +27,13 @@ module Lhm
   #
   # @param [String, Symbol] table_name Name of the table
   # @param [Hash] options Optional options to alter the chunk / switch behavior
-  # @option options [Fixnum] :stride
+  # @option options [Integer] :stride
   #   Size of a chunk (defaults to: 2,000)
-  # @option options [Fixnum] :throttle
+  # @option options [Integer] :throttle
   #   Time to wait between chunks in milliseconds (defaults to: 100)
-  # @option options [Fixnum] :start
+  # @option options [Integer] :start
   #   Primary Key position at which to start copying chunks
-  # @option options [Fixnum] :limit
+  # @option options [Integer] :limit
   #   Primary Key position at which to stop copying chunks
   # @option options [Boolean] :atomic_switch
   #   Use atomic switch to rename tables (defaults to: true)

--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -66,7 +66,7 @@ module Lhm
     end
 
     def should_retry_exception?(error)
-      defined?(Mysql2) && error.message =~ /Lock wait timeout exceeded/
+      error.message =~ /Lock wait timeout exceeded/
     end
   end
 end

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -51,7 +51,7 @@ describe Lhm::Chunker do
       23.times { |n| execute("insert into origin set id = '#{ n * n + 23 }'") }
 
       printer = MiniTest::Mock.new
-      printer.expect(:notify, :return_value, [Fixnum, Fixnum])
+      printer.expect(:notify, :return_value, [Integer, Integer])
       printer.expect(:end, :return_value, [])
 
       Lhm::Chunker.new(
@@ -88,7 +88,7 @@ describe Lhm::Chunker do
       23.times { |n| execute("insert into origin set id = '#{ 100000 + n * n + 23 }'") }
 
       printer = MiniTest::Mock.new
-      printer.expect(:notify, :return_value, [Fixnum, Fixnum])
+      printer.expect(:notify, :return_value, [Integer, Integer])
       printer.expect(:end, :return_value, [])
 
       Lhm::Chunker.new(
@@ -106,7 +106,7 @@ describe Lhm::Chunker do
       15.times { |n| execute("insert into origin set id = '#{ (n * n) + 1 }'") }
 
       printer = mock()
-      printer.expects(:notify).with(instance_of(Fixnum), instance_of(Fixnum)).twice
+      printer.expects(:notify).with(instance_of(Integer), instance_of(Integer)).twice
       printer.expects(:end)
 
       throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0)
@@ -129,7 +129,7 @@ describe Lhm::Chunker do
       15.times { |n| execute("insert into origin set id = '#{ (n * n) + 1 }'") }
 
       printer = mock()
-      printer.expects(:notify).with(instance_of(Fixnum), instance_of(Fixnum)).twice
+      printer.expects(:notify).with(instance_of(Integer), instance_of(Integer)).twice
       printer.expects(:verify)
       printer.expects(:end)
 

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -141,11 +141,10 @@ describe Lhm::Chunker do
 
       if master_slave_mode?
         def throttler.slave_connection(slave)
-          adapter_method = defined?(Mysql2) ? 'mysql2_connection' : 'mysql_connection'
           config = ActiveRecord::Base.connection_pool.spec.config.dup
           config[:host] = slave
           config[:port] = 3307
-          ActiveRecord::Base.send(adapter_method, config)
+          ActiveRecord::Base.send('mysql2_connection', config)
         end
       end
 

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -4,7 +4,7 @@
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'minitest/mock'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'pathname'
 require 'lhm'
 

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -13,11 +13,7 @@ $spec = $project.join('spec')
 $fixtures = $spec.join('fixtures')
 
 require 'active_record'
-begin
-  require 'mysql2'
-rescue LoadError
-  require 'mysql'
-end
+require 'mysql2'
 
 logger = Logger.new STDOUT
 logger.level = Logger::WARN


### PR DESCRIPTION
* Remove mysql2 conditionals: There should not be any Shopify apps using the mysql gem, everyone should
be using mysql2.
* Fix mocha/mini_test deprecation warning
* Replace Fixnum with Integer: https://blog.bigbinary.com/2016/11/18/ruby-2-4-unifies-fixnum-and-bignum-into-integer.html