### PR TITLE
Unify Entangler and AtomicSwitcher retry interface

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     lhm (3.0.0)
+      retriable
 
 GEM
   remote: https://rubygems.org/
@@ -51,6 +52,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    retriable (3.1.2)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)

--- a/lhm.gemspec
+++ b/lhm.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.executables   = ['lhm-kill-queue']
 
+  s.required_ruby_version = '>= 2.3.0'
+
   s.add_dependency 'retriable'
 
   s.add_development_dependency 'minitest'

--- a/lhm.gemspec
+++ b/lhm.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.executables   = ['lhm-kill-queue']
 
+  s.add_dependency 'retriable'
+
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rake'

--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -13,20 +13,19 @@ module Lhm
   # Lhm::SqlHelper.supports_atomic_switch?.
   class AtomicSwitcher
     include Command
+    include RetryHelper
 
     attr_reader :connection
-
-    DEFAULT_MAX_RETRIES = 600
-    DEFAULT_RETRY_WAIT = 10
-    include RetryHelper
 
     def initialize(migration, connection = nil, options = {})
       @migration = migration
       @connection = connection
       @origin = migration.origin
       @destination = migration.destination
-      @max_retries = options[:max_retries]
-      @retry_wait = options[:retry_wait]
+      configure_retry({
+        tries: options[:max_retries] || 600,
+        base_interval: options[:retry_wait] || 10
+      })
     end
 
     def atomic_switch

--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -23,8 +23,8 @@ module Lhm
       @origin = migration.origin
       @destination = migration.destination
       configure_retry({
-        tries: options[:max_retries] || 600,
-        base_interval: options[:retry_wait] || 10
+        tries: options.dig(:retriable, :tries) || 600,
+        base_interval: options.dig(:retriable, :base_interval) || 10
       })
     end
 

--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -3,7 +3,6 @@
 
 require 'lhm/command'
 require 'lhm/migration'
-require 'lhm/sql_helper'
 require 'lhm/retry_helper'
 
 module Lhm
@@ -45,9 +44,7 @@ module Lhm
     private
 
     def execute
-      Retriable.retriable(retry_config) do
-        @connection.execute(SqlHelper.tagged(atomic_switch))
-      end
+      execute_with_retries(atomic_switch)
     end
   end
 end

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -21,8 +21,8 @@ module Lhm
       @destination = migration.destination
       @connection = connection
       configure_retry({
-        tries: options[:max_retries] || 10,
-        base_interval: options[:retry_wait] || 1
+        tries: options.dig(:retriable, :tries) || 10,
+        base_interval: options.dig(:retriable, :base_interval) || 1
       })
     end
 

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -9,12 +9,9 @@ module Lhm
   class Entangler
     include Command
     include SqlHelper
+    include RetryHelper
 
     attr_reader :connection
-
-    DEFAULT_MAX_RETRIES = 10
-    DEFAULT_RETRY_WAIT = 1
-    include RetryHelper
 
     # Creates entanglement between two tables. All creates, updates and deletes
     # to origin will be repeated on the destination table.
@@ -23,8 +20,10 @@ module Lhm
       @origin = migration.origin
       @destination = migration.destination
       @connection = connection
-      @max_retries = options[:max_retries]
-      @retry_wait = options[:retry_wait]
+      configure_retry({
+        tries: options[:max_retries] || 10,
+        base_interval: options[:retry_wait] || 1
+      })
     end
 
     def entangle

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -90,17 +90,13 @@ module Lhm
 
     def before
       entangle.each do |stmt|
-        Retriable.retriable(retry_config) do
-          @connection.execute(tagged(stmt))
-        end
+        execute_with_retries(stmt)
       end
     end
 
     def after
       untangle.each do |stmt|
-        Retriable.retriable(retry_config) do
-          @connection.execute(tagged(stmt))
-        end
+        execute_with_retries(stmt)
       end
     end
 

--- a/lib/lhm/retry_helper.rb
+++ b/lib/lhm/retry_helper.rb
@@ -5,44 +5,37 @@ module Lhm
   # RetryHelper standardizes the interface for retry behavior in components like
   # Entangler and AtomicSwitcher.
   #
-  # It expects the caller to implement:
-  # DEFAULT_MAX_RETRIES
-  # DEFAULT_RETRY_WAIT
-  #
-  # These defaults can be overridden by setting an instance variable with corresponding names:
-  # @max_retries
-  # @retry_wait
-  #
   # To retry some behavior, use `execute_with_retries(statement)`
   # which assumes `@connection` is available.
+  #
+  # `execute_with_retries` expects the caller to invoke `configure_retry` first, providing:
+  # * `max_retries` as an integer
+  # * `retry_wait` as an integer
   module RetryHelper
-    def self.included(base)
-      raise(ArgumentError, "#{base} must define DEFAULT_MAX_RETRIES before calling 'include RetryHelper'") unless base.constants.include?(:DEFAULT_MAX_RETRIES)
-      raise(ArgumentError, "#{base} must define DEFAULT_RETRY_WAIT before calling 'include RetryHelper'") unless base.constants.include?(:DEFAULT_RETRY_WAIT)
-    end
-
     def execute_with_retries(statement)
       Retriable.retriable(retry_config) do
         @connection.execute(SqlHelper.tagged(statement))
       end
     end
 
+    def configure_retry(options)
+      @retry_config = DEFAULT_RETRY_CONFIG.merge(options)
+    end
+
+    attr_reader :retry_config
+
     private
 
-    def retry_config
-      {
-        on: {
-          StandardError => [/Lock wait timeout exceeded/]
-        },
-        tries: @max_retries || self.class::DEFAULT_MAX_RETRIES, # number of attempts
-        base_interval: @retry_wait || self.class::DEFAULT_RETRY_WAIT, # initial interval in seconds between tries
-        multiplier: 1.5, # each successive interval grows by this factor
-        rand_factor: 0.25, # percentage to randomize the next retry interval time
-        max_elapsed_time: Float::INFINITY, # max total time in seconds that code is allowed to keep being retried
-        on_retry: Proc.new do |exception, try, elapsed_time, next_interval|
-          Lhm.logger.info("#{exception.class}: '#{exception.message}' - #{try} tries in #{elapsed_time} seconds and #{next_interval} seconds until the next try.")
-        end
-      }
-    end
+    DEFAULT_RETRY_CONFIG = {
+      on: {
+        StandardError => [/Lock wait timeout exceeded/]
+      },
+      multiplier: 1.5, # each successive interval grows by this factor
+      rand_factor: 0.25, # percentage to randomize the next retry interval time
+      max_elapsed_time: Float::INFINITY, # max total time in seconds that code is allowed to keep being retried
+      on_retry: Proc.new do |exception, try, elapsed_time, next_interval|
+        Lhm.logger.info("#{exception.class}: '#{exception.message}' - #{try} tries in #{elapsed_time} seconds and #{next_interval} seconds until the next try.")
+      end
+    }.freeze
   end
 end

--- a/lib/lhm/retry_helper.rb
+++ b/lib/lhm/retry_helper.rb
@@ -9,8 +9,10 @@ module Lhm
   # which assumes `@connection` is available.
   #
   # `execute_with_retries` expects the caller to invoke `configure_retry` first, providing:
-  # * `max_retries` as an integer
-  # * `retry_wait` as an integer
+  # * `tries` as an integer
+  # * `base_interval` as an integer
+  #
+  # For a full list of configuration options see https://github.com/kamui/retriable
   module RetryHelper
     def execute_with_retries(statement)
       Retriable.retriable(retry_config) do

--- a/lib/lhm/retry_helper.rb
+++ b/lib/lhm/retry_helper.rb
@@ -1,0 +1,41 @@
+require 'retriable'
+
+module Lhm
+  # RetryHelper standardizes the interface for retry behavior in components like
+  # Entangler and AtomicSwitcher.
+  #
+  # It expects the caller to implement:
+  # DEFAULT_MAX_RETRIES
+  # DEFAULT_RETRY_WAIT
+  #
+  # These defaults can be overridden by setting an instance variable with corresponding names:
+  # @max_retries
+  # @retry_wait
+  #
+  # To retry some behavior:
+  # Retriable.retriable(retry_config) do
+  #   @connection.execute(tagged(stmt))
+  # end
+  module RetryHelper
+    def self.included(base)
+      raise(ArgumentError, "#{base} must define DEFAULT_MAX_RETRIES before calling 'include RetryHelper'") unless base.constants.include?(:DEFAULT_MAX_RETRIES)
+      raise(ArgumentError, "#{base} must define DEFAULT_RETRY_WAIT before calling 'include RetryHelper'") unless base.constants.include?(:DEFAULT_RETRY_WAIT)
+    end
+
+    def retry_config
+      {
+        on: {
+          StandardError => [/Lock wait timeout exceeded/]
+        },
+        tries: @max_retries || self.class::DEFAULT_MAX_RETRIES, # number of attempts
+        base_interval: @retry_wait || self.class::DEFAULT_RETRY_WAIT, # initial interval in seconds between tries
+        multiplier: 1.5, # each successive interval grows by this factor
+        rand_factor: 0.25, # percentage to randomize the next retry interval time
+        max_elapsed_time: Float::INFINITY, # max total time in seconds that code is allowed to keep being retried
+        on_retry: Proc.new do |exception, try, elapsed_time, next_interval|
+          Lhm.logger.info("#{exception.class}: '#{exception.message}' - #{try} tries in #{elapsed_time} seconds and #{next_interval} seconds until the next try.")
+        end
+      }
+    end
+  end
+end

--- a/spec/unit/entangler_spec.rb
+++ b/spec/unit/entangler_spec.rb
@@ -60,11 +60,11 @@ describe Lhm::Entangler do
     end
 
     it 'should retry trigger creation when it hits a lock wait timeout' do
-      expected_calls = Lhm::Entangler::LOCK_WAIT_RETRIES + 1
+      expected_calls = Lhm::Entangler::LOCK_WAIT_RETRIES
       connection = mock()
       connection.expects(:execute).times(expected_calls).raises(Mysql2::Error, 'Lock wait timeout exceeded; try restarting transaction')
 
-      @entangler.instance_variable_set(:@connection, connection)
+      @entangler = Lhm::Entangler.new(@migration, connection, {retry_wait: 0})
       assert_raises(Mysql2::Error) { @entangler.before }
     end
 
@@ -72,36 +72,24 @@ describe Lhm::Entangler do
       connection = mock()
       connection.expects(:execute).once.raises(Mysql2::Error, 'The MySQL server is running with the --read-only option so it cannot execute this statement.')
 
-      @entangler.instance_variable_set(:@connection, connection)
+      @entangler = Lhm::Entangler.new(@migration, connection, {retry_wait: 0})
       assert_raises(Mysql2::Error) { @entangler.before }
     end
 
     it 'should succesfully finish after retrying' do
       connection = mock()
       connection.stubs(:execute).raises(Mysql2::Error, 'Lock wait timeout exceeded; try restarting transaction').then.returns(true)
-      @entangler.instance_variable_set(:@connection, connection)
-
-      Kernel.expects(:sleep).once
+      @entangler = Lhm::Entangler.new(@migration, connection, {retry_wait: 0})
 
       assert @entangler.before
     end
 
     it 'should retry as many times as specified by lock_wait_retries' do
       connection = mock()
-      connection.expects(:execute).times(6).raises(Mysql2::Error, 'Lock wait timeout exceeded; try restarting transaction')
-      entangler = Lhm::Entangler.new(@migration, connection, {lock_wait_retries: 5})
+      connection.expects(:execute).times(5).raises(Mysql2::Error, 'Lock wait timeout exceeded; try restarting transaction')
+      @entangler = Lhm::Entangler.new(@migration, connection, {lock_wait_retries: 5, retry_wait: 0})
 
-      assert_raises(Mysql2::Error) { entangler.before }
-    end
-
-    it 'should sleep as long as specified by retry_wait' do
-      connection = mock()
-      connection.stubs(:execute).raises(Mysql2::Error, 'Lock wait timeout exceeded; try restarting transaction').then.returns(true)
-      entangler = Lhm::Entangler.new(@migration, connection, {retry_wait: 3})
-
-      Kernel.expects(:sleep).with(3)
-
-      assert entangler.before
+      assert_raises(Mysql2::Error) { @entangler.before }
     end
 
     describe 'super long table names' do

--- a/spec/unit/entangler_spec.rb
+++ b/spec/unit/entangler_spec.rb
@@ -60,7 +60,7 @@ describe Lhm::Entangler do
     end
 
     it 'should retry trigger creation when it hits a lock wait timeout' do
-      expected_calls = Lhm::Entangler::LOCK_WAIT_RETRIES
+      expected_calls = Lhm::Entangler::DEFAULT_MAX_RETRIES
       connection = mock()
       connection.expects(:execute).times(expected_calls).raises(Mysql2::Error, 'Lock wait timeout exceeded; try restarting transaction')
 
@@ -84,10 +84,10 @@ describe Lhm::Entangler do
       assert @entangler.before
     end
 
-    it 'should retry as many times as specified by lock_wait_retries' do
+    it 'should retry as many times as specified by max_retries' do
       connection = mock()
       connection.expects(:execute).times(5).raises(Mysql2::Error, 'Lock wait timeout exceeded; try restarting transaction')
-      @entangler = Lhm::Entangler.new(@migration, connection, {lock_wait_retries: 5, retry_wait: 0})
+      @entangler = Lhm::Entangler.new(@migration, connection, {max_retries: 5, retry_wait: 0})
 
       assert_raises(Mysql2::Error) { @entangler.before }
     end

--- a/spec/unit/entangler_spec.rb
+++ b/spec/unit/entangler_spec.rb
@@ -60,11 +60,11 @@ describe Lhm::Entangler do
     end
 
     it 'should retry trigger creation when it hits a lock wait timeout' do
-      expected_calls = Lhm::Entangler::DEFAULT_MAX_RETRIES
       connection = mock()
+      @entangler = Lhm::Entangler.new(@migration, connection, {retry_wait: 0})
+      expected_calls = @entangler.retry_config[:tries]
       connection.expects(:execute).times(expected_calls).raises(Mysql2::Error, 'Lock wait timeout exceeded; try restarting transaction')
 
-      @entangler = Lhm::Entangler.new(@migration, connection, {retry_wait: 0})
       assert_raises(Mysql2::Error) { @entangler.before }
     end
 


### PR DESCRIPTION
These two classes both implementing a retry-on-exception pattern.
Chunker will be the third consumer of this pattern.
Let's make reusing this pattern very easy while making the implementation
consistent.

This change offers several improvements:
* No homegrown retry logic
* Retries now have more configuration choices
* Retries now backoff
* Better logging during retries
* Fixes a N+1 assertion in the test suite
* Fixes a slow unit test
* Stops usage of entangler.instance_variable_set