### PR TITLE
Rename lhmn_ tables to lhma_ to avoid IBP stalls

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -5,6 +5,7 @@ require 'lhm/table'
 require 'lhm/invoker'
 require 'lhm/throttler'
 require 'lhm/version'
+require 'lhm/cleanup/current'
 require 'logger'
 
 # Large hadron migrator - online schema change tool
@@ -73,12 +74,7 @@ module Lhm
   end
 
   def cleanup_current_run(run, table_name)
-    lhm_table = connection.select_values("show tables like 'lhmn_#{table_name}'")
-    lhm_triggers = connection.select_values("show triggers like '%#{table_name}'").collect do |trigger|
-      trigger.respond_to?(:trigger) ? trigger.trigger : trigger
-    end.select { |name| name =~ /^lhmt/ }
-
-    drop_tables_and_triggers(run, lhm_triggers, lhm_table)
+    Lhm::Cleanup::Current.new(run, table_name, connection).execute
   end
 
   def setup(connection)

--- a/lib/lhm/cleanup/current.rb
+++ b/lib/lhm/cleanup/current.rb
@@ -1,3 +1,5 @@
+require 'lhm/timestamp'
+
 module Lhm
   module Cleanup
     class Current
@@ -12,7 +14,7 @@ module Lhm
 
       def execute
         build_statements_for_drop_lhm_triggers_for_origin
-        build_statements_for_drop_lhmn_tables_for_origin
+        build_statements_for_rename_lhmn_tables_for_origin
         if run
           execute_ddls
         else
@@ -38,14 +40,18 @@ module Lhm
         end
       end
 
-      def build_statements_for_drop_lhmn_tables_for_origin
+      def build_statements_for_rename_lhmn_tables_for_origin
         lhmn_tables_for_origin.each do |table|
-          @ddls << "drop table if exists #{table}"
+          @ddls << "rename table #{table} to #{failed_name}"
         end
       end
 
       def lhmn_tables_for_origin
         @lhmn_tables_for_origin ||= connection.select_values("show tables like 'lhmn_#{origin_table_name}'")
+      end
+
+      def failed_name
+        "lhma_#{Timestamp.new(Time.now)}_#{origin_table_name}_failed"
       end
 
       def execute_ddls

--- a/lib/lhm/cleanup/current.rb
+++ b/lib/lhm/cleanup/current.rb
@@ -1,0 +1,62 @@
+module Lhm
+  module Cleanup
+    class Current
+      def initialize(run, origin_table_name, connection)
+        @run = run
+        @origin_table_name = origin_table_name
+        @connection = connection
+      end
+
+      attr_reader :run, :origin_table_name, :connection
+
+      def execute
+        if run
+          drop_lhm_triggers_for_origin
+          drop_lhmn_tables_for_origin
+        else
+          report
+        end
+      end
+
+      private
+
+      def drop_lhm_triggers_for_origin
+        lhm_triggers_for_origin.each do |trigger|
+          connection.execute("drop trigger if exists #{trigger}")
+        end
+      end
+
+      def lhm_triggers_for_origin
+        @lhm_triggers_for_origin ||= all_triggers_for_origin.select { |name| name =~ /^lhmt/ }
+      end
+
+      def all_triggers_for_origin
+        @all_triggers_for_origin ||= connection.select_values("show triggers like '%#{origin_table_name}'").collect do |trigger|
+          trigger.respond_to?(:trigger) ? trigger.trigger : trigger
+        end
+      end
+
+      def drop_lhmn_tables_for_origin
+        lhmn_tables_for_origin.each do |table|
+          connection.execute("drop table if exists #{table}")
+        end
+      end
+
+      def lhmn_tables_for_origin
+        @lhmn_tables_for_origin ||= connection.select_values("show tables like 'lhmn_#{origin_table_name}'")
+      end
+
+      def report
+        if lhmn_tables_for_origin.empty? && lhm_triggers_for_origin.empty?
+          puts 'Everything is clean. Nothing to do.'
+          true
+        else
+          puts "Would drop LHM backup tables: #{lhmn_tables_for_origin.join(', ')}."
+          puts "Would drop LHM triggers: #{lhm_triggers_for_origin.join(', ')}."
+          puts 'Run with Lhm.cleanup(true) to drop all LHM triggers and tables, or Lhm.cleanup_current_run(true, table_name) to clean up a specific LHM.'
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/lhm/migration.rb
+++ b/lib/lhm/migration.rb
@@ -2,6 +2,7 @@
 # Schmidt
 
 require 'lhm/intersection'
+require 'lhm/timestamp'
 
 module Lhm
   class Migration
@@ -24,7 +25,7 @@ module Lhm
     end
 
     def startstamp
-      @start.strftime "%Y_%m_%d_%H_%M_%S_#{ '%03d' % (@start.usec / 1000) }"
+      Timestamp.new(@start)
     end
   end
 end

--- a/lib/lhm/timestamp.rb
+++ b/lib/lhm/timestamp.rb
@@ -1,0 +1,11 @@
+module Lhm
+  class Timestamp
+    def initialize(time)
+      @time = time
+    end
+
+    def to_s
+      @time.strftime "%Y_%m_%d_%H_%M_%S_#{ '%03d' % (@time.usec / 1000) }"
+    end
+  end
+end

--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -104,7 +104,7 @@ describe Lhm, 'cleanup' do
         assert_equal "drop trigger if exists lhmt_ins_permissions", output[1]
         assert_equal "drop trigger if exists lhmt_upd_permissions", output[2]
         assert_equal "drop trigger if exists lhmt_del_permissions", output[3]
-        assert_equal "drop table if exists lhmn_permissions", output[4]
+        assert_match(/rename table lhmn_permissions to lhma_[0-9_]*_permissions_failed/, output[4])
         assert_equal 5, output.length
       end
 

--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -98,24 +98,25 @@ describe Lhm, 'cleanup' do
         table_rename(:permissions, 'lhmn_permissions')
         output = capture_stdout do
           Lhm.cleanup_current_run(false, 'permissions')
-        end
-        output.must_include('Would drop LHM backup tables')
-        output.must_match(/lhmn_permissions/)
-        output.wont_match(/lhma_[0-9_]*_permissions/)
-        output.wont_match(/lhma_[0-9_]*_users/)
+        end.split("\n")
+
+        assert_equal "The following DDLs would be executed:", output[0]
+        assert_equal "drop trigger if exists lhmt_ins_permissions", output[1]
+        assert_equal "drop trigger if exists lhmt_upd_permissions", output[2]
+        assert_equal "drop trigger if exists lhmt_del_permissions", output[3]
+        assert_equal "drop table if exists lhmn_permissions", output[4]
+        assert_equal 5, output.length
       end
 
       it 'should show temporary triggers for the specified table only' do
         output = capture_stdout do
           Lhm.cleanup_current_run(false, 'permissions')
-        end
-        output.must_include('Would drop LHM triggers')
-        output.wont_include('lhmt_ins_users')
-        output.wont_include('lhmt_del_users')
-        output.wont_include('lhmt_upd_users')
-        output.must_include('lhmt_ins_permissions')
-        output.must_include('lhmt_del_permissions')
-        output.must_include('lhmt_upd_permissions')
+        end.split("\n")
+        assert_equal "The following DDLs would be executed:", output[0]
+        assert_equal "drop trigger if exists lhmt_ins_permissions", output[1]
+        assert_equal "drop trigger if exists lhmt_upd_permissions", output[2]
+        assert_equal "drop trigger if exists lhmt_del_permissions", output[3]
+        assert_equal 4, output.length
       end
 
       it 'should delete temporary tables and triggers for the specified table only' do


### PR DESCRIPTION
When an LHM worker fails, `cleanup_current_run` must be called to remove
the triggers and "new" tables (which start with lhmn_). The previous
behavior was to drop the table immediately. However, if this is an active
table, the InnoDB buffer pool can be full of pages related to this "lhmn_"
table. When it is dropped, this forces IBP to clear to those pages and can
cause MySQL to become unresponsive.

By instead renaming this table with the archive prefix (lhma_) when can let
the buffer unload relevant pages overtime, and then later, safely, drop the
archive tables as part of regular scheduled maintenance.