### PR TITLE
Retry ChunkInsert

### DIFF
--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -43,7 +43,7 @@ module Lhm
     private
 
     def execute
-      execute_with_retries(atomic_switch)
+      connection_with_retries(statement: atomic_switch, invoke_with: :execute)
     end
   end
 end

--- a/lib/lhm/chunk_insert.rb
+++ b/lib/lhm/chunk_insert.rb
@@ -1,13 +1,14 @@
 module Lhm
   class ChunkInsert
-    def initialize(migration, lowest, highest)
+    def initialize(migration, connection, lowest, highest)
       @migration = migration
+      @connection = connection
       @lowest = lowest
       @highest = highest
     end
 
-    def insert_and_return_count_of_rows_created(connection)
-      connection.update(sql)
+    def insert_and_return_count_of_rows_created
+      @connection.update(sql)
     end
 
     def sql

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -33,7 +33,7 @@ module Lhm
       while @next_to_insert <= @limit || (@start == @limit)
         stride = @throttler.stride
         top = upper_id(@next_to_insert, stride)
-        affected_rows = ChunkInsert.new(@migration, bottom, top).insert_and_return_count_of_rows_created(@connection)
+        affected_rows = ChunkInsert.new(@migration, @connection, bottom, top).insert_and_return_count_of_rows_created
         if @throttler && affected_rows > 0
           @throttler.run
         end

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -89,13 +89,13 @@ module Lhm
 
     def before
       entangle.each do |stmt|
-        execute_with_retries(stmt)
+        connection_with_retries(statement: stmt, invoke_with: :execute)
       end
     end
 
     def after
       untangle.each do |stmt|
-        execute_with_retries(stmt)
+        connection_with_retries(statement: stmt, invoke_with: :execute)
       end
     end
 

--- a/lib/lhm/retry_helper.rb
+++ b/lib/lhm/retry_helper.rb
@@ -5,18 +5,18 @@ module Lhm
   # RetryHelper standardizes the interface for retry behavior in components like
   # Entangler and AtomicSwitcher.
   #
-  # To retry some behavior, use `execute_with_retries(statement)`
+  # To retry some behavior, use `connection_with_retries(statement: sql, invoke_with: :execute)`
   # which assumes `@connection` is available.
   #
-  # `execute_with_retries` expects the caller to invoke `configure_retry` first, providing:
+  # `connection_with_retries` expects the caller to invoke `configure_retry` first, providing:
   # * `tries` as an integer
   # * `base_interval` as an integer
   #
   # For a full list of configuration options see https://github.com/kamui/retriable
   module RetryHelper
-    def execute_with_retries(statement)
+    def connection_with_retries(statement:, invoke_with:)
       Retriable.retriable(retry_config) do
-        @connection.execute(SqlHelper.tagged(statement))
+        @connection.public_send(invoke_with, SqlHelper.tagged(statement))
       end
     end
 

--- a/spec/integration/chunk_insert_spec.rb
+++ b/spec/integration/chunk_insert_spec.rb
@@ -11,15 +11,15 @@ describe Lhm::ChunkInsert do
       @destination = table_create(:destination)
       @migration = Lhm::Migration.new(@origin, @destination)
       execute("insert into origin set id = 1001")
-      @instance = Lhm::ChunkInsert.new(@migration, 1001, 1001)
+      @instance = Lhm::ChunkInsert.new(@migration, connection, 1001, 1001)
     end
 
     it "returns the count" do
-      assert_equal 1, @instance.insert_and_return_count_of_rows_created(connection)
+      assert_equal 1, @instance.insert_and_return_count_of_rows_created
     end
 
     it "inserts the record into the slave" do
-      @instance.insert_and_return_count_of_rows_created(connection)
+      @instance.insert_and_return_count_of_rows_created
 
       slave do
         count_all(@destination.name).must_equal(1)

--- a/spec/unit/chunk_insert_spec.rb
+++ b/spec/unit/chunk_insert_spec.rb
@@ -7,6 +7,7 @@ require 'lhm/chunk_insert'
 
 describe Lhm::ChunkInsert do
   before(:each) do
+    @connection = stub(:connection)
     @origin = Lhm::Table.new('foo')
     @destination = Lhm::Table.new('bar')
   end
@@ -17,7 +18,7 @@ describe Lhm::ChunkInsert do
 
       it "uses a simple where clause" do
         assert_equal(
-          Lhm::ChunkInsert.new(@migration, 1, 2).sql,
+          Lhm::ChunkInsert.new(@migration, @connection, 1, 2).sql,
           "insert ignore into `bar` () select  from `foo` where `foo`.`id` between 1 and 2"
         )
       end
@@ -34,7 +35,7 @@ describe Lhm::ChunkInsert do
 
       it "combines the clause with the chunking WHERE condition" do
         assert_equal(
-          Lhm::ChunkInsert.new(@migration, 1, 2).sql,
+          Lhm::ChunkInsert.new(@migration, @connection, 1, 2).sql,
           "insert ignore into `bar` () select  from `foo` where (foo.created_at > '2013-07-10' or foo.baz = 'quux') and `foo`.`id` between 1 and 2"
         )
       end


### PR DESCRIPTION
If we encounter any error whose message contains "Lock wait timeout exceeded"
while copying data from the old table to the new table (the Chunker's job) then retry.