### PR TITLE
Code to fix too long table named

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -61,7 +61,7 @@ module Lhm
     lhm_tables = connection.select_values('show tables').select { |name| name =~ /^lhm(a|n)_/ }
     if options[:until]
       lhm_tables.select! do |table|
-        table_date_time = Time.strptime(table, 'lhma_%Y_%m_%d_%H_%M_%S')
+        table_date_time = Time.strptime(table, 'lhma_%Y%m%d%H%M%S')
         table_date_time <= options[:until]
       end
     end

--- a/lib/lhm/cleanup/current.rb
+++ b/lib/lhm/cleanup/current.rb
@@ -51,7 +51,8 @@ module Lhm
       end
 
       def failed_name
-        "lhma_#{Timestamp.new(Time.now)}_#{origin_table_name}_failed"
+        # NOTE: MySQL table names are limited to 64 characters
+        "lhma_#{Timestamp.new(Time.now)}_#{origin_table_name}_failed"[0..63]
       end
 
       def execute_ddls

--- a/lib/lhm/timestamp.rb
+++ b/lib/lhm/timestamp.rb
@@ -5,7 +5,7 @@ module Lhm
     end
 
     def to_s
-      @time.strftime "%Y_%m_%d_%H_%M_%S_#{ '%03d' % (@time.usec / 1000) }"
+      @time.strftime "%Y%m%d%H%M%S"
     end
   end
 end

--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end

--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -134,15 +134,6 @@ describe Lhm, 'cleanup' do
     end
 
     describe 'failed_name' do
-      before do
-        @fake_time = Time.now
-        Time.stubs(:now).returns(@fake_time)
-      end
-
-      after do
-        Time.unstub(:now)
-      end
-
       it 'should provide a table name with a maximum length of 64' do
         cleanup = Lhm::Cleanup::Current.new(nil, 'some_excessively_long_table_name_oh_dear_code_who_would_even_do_this_and_why', nil)
         assert_equal cleanup.instance_eval { failed_name }.size, 64

--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -132,5 +132,21 @@ describe Lhm, 'cleanup' do
         assert all_triggers.find { |t| t =~ /lhmt_(.*)_users/}
       end
     end
+
+    describe 'failed_name' do
+      before do
+        @fake_time = Time.now
+        Time.stubs(:now).returns(@fake_time)
+      end
+
+      after do
+        Time.unstub(:now)
+      end
+
+      it 'should provide a table name with a maximum length of 64' do
+        cleanup = Lhm::Cleanup::Current.new(nil, 'some_excessively_long_table_name', nil)
+        assert_equal cleanup.instance_eval { failed_name }, "lhma_#{Lhm::Timestamp.new(Time.now)}_some_excessively_long_table_name_fa"
+      end
+    end
   end
 end

--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -144,8 +144,8 @@ describe Lhm, 'cleanup' do
       end
 
       it 'should provide a table name with a maximum length of 64' do
-        cleanup = Lhm::Cleanup::Current.new(nil, 'some_excessively_long_table_name', nil)
-        assert_equal cleanup.instance_eval { failed_name }, "lhma_#{Lhm::Timestamp.new(Time.now)}_some_excessively_long_table_name_fa"
+        cleanup = Lhm::Cleanup::Current.new(nil, 'some_excessively_long_table_name_oh_dear_code_who_would_even_do_this_and_why', nil)
+        assert_equal cleanup.instance_eval { failed_name }.size, 64
       end
     end
   end

--- a/spec/unit/migration_spec.rb
+++ b/spec/unit/migration_spec.rb
@@ -17,7 +17,7 @@ describe Lhm::Migration do
   end
 
   it 'should name archive' do
-    stamp = "%Y_%m_%d_%H_%M_%S_#{ '%03d' % (@start.usec / 1000) }"
+    stamp = "%Y%m%d%H%M%S"
     @migration.archive_name.must_equal "lhma_#{ @start.strftime(stamp) }_origin"
   end
 


### PR DESCRIPTION
MySQL has a maximum table name length limit of 64 bytes, so we need to make sure to not generate table names longer than this. The table names are still guaranteed to be unique, as we have usec-precision Timestamps in them.