### PR TITLE
Loosen dependency on retriable gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     lhm (3.1.1)
-      retriable (>= 3.0.0)
+      retriable
 
 GEM
   remote: https://rubygems.org/

--- a/lhm.gemspec
+++ b/lhm.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_dependency 'retriable', '>= 3.0.0'
+  s.add_dependency 'retriable'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'

--- a/lib/lhm/sql_retry.rb
+++ b/lib/lhm/sql_retry.rb
@@ -35,7 +35,13 @@ module Lhm
     def default_retry_config
       {
         on: {
-          StandardError => [
+          ActiveRecord::LockWaitTimeout => nil,
+          ActiveRecord::Deadlocked => nil,
+          Mysql2::Error => [
+            /Lock wait timeout exceeded/,
+            /Deadlock found when trying to get lock/,
+          ],
+          Exception => [
             /Lock wait timeout exceeded/,
             /Deadlock found when trying to get lock/,
           ]


### PR DESCRIPTION
Given:
* retries are not configurable from outside the library yet (https://github.com/Shopify/lhm/issues/53)
* Shopify is the primary consumer of this library

When:
* Shopify cannot currently use retriable >=3 (https://github.com/Shopify/shopify/pull/167954)

Then:
* You get this PR!

The primary feature that we care about from the pre-3.0 release is https://github.com/kamui/retriable/pull/24
which targets subclasses of exceptions. Since we're loosing that, we'll just duplicate the error classes from which we might expect the errors we want to retry.