### PR TITLE
Slave lag throttler symbolize config keys

### DIFF
--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -108,7 +108,7 @@ module Lhm
 
       def client(config)
         begin
-          Lhm.logger.info "Connecting to #{@host} on database: #{config['database']}"
+          Lhm.logger.info "Connecting to #{@host} on database: #{config[:database]}"
           Mysql2::Client.new(config)
         rescue Mysql2::Error => e
           Lhm.logger.info "Error connecting to #{@host}: #{e}"
@@ -118,7 +118,8 @@ module Lhm
 
       def config(get_config)
         config = get_config ? get_config.call : ActiveRecord::Base.connection_pool.spec.config.dup
-        config['host'] = @host
+        config.deep_symbolize_keys!
+        config[:host] = @host
         config
       end
 

--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -91,9 +91,10 @@ module Lhm
 
       attr_reader :host, :connection
 
-      def initialize(host, get_config=nil)
+      def initialize(host, connection_config = nil)
         @host = host
-        @connection = client(config(get_config))
+        @connection_config = prepare_connection_config(connection_config)
+        @connection = client(@connection_config)
       end
 
       def slave_hosts
@@ -116,8 +117,16 @@ module Lhm
         end
       end
 
-      def config(get_config)
-        config = get_config ? get_config.call : ActiveRecord::Base.connection_pool.spec.config.dup
+      def prepare_connection_config(config_proc)
+        config = if config_proc
+          if config_proc.respond_to?(:call) # if we get a proc
+            config_proc.call
+          else
+            raise ArgumentError, "Expected #{config_proc.inspect} to respond to `call`"
+          end
+        else # otherwise default to ActiveRecord provided config
+          ActiveRecord::Base.connection_pool.spec.config.dup
+        end
         config.deep_symbolize_keys!
         config[:host] = @host
         config

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -39,9 +39,7 @@ describe Lhm::Throttler::Slave do
     @logs = StringIO.new
     Lhm.logger = Logger.new(@logs)
 
-    def get_config
-      lambda { {'username' => 'user', 'password' => 'pw', 'database' => 'db'} }
-    end
+    @dummy_mysql_client_config = lambda { {'username' => 'user', 'password' => 'pw', 'database' => 'db'} }
   end
 
   describe "#client" do
@@ -55,7 +53,7 @@ describe Lhm::Throttler::Slave do
 
     describe 'on connection error' do
       it 'logs and returns nil' do
-        assert_nil(Lhm::Throttler::Slave.new('slave', get_config).connection)
+        assert_nil(Lhm::Throttler::Slave.new('slave', @dummy_mysql_client_config).connection)
 
         log_messages = @logs.string.lines
         assert_equal(2, log_messages.length)
@@ -69,7 +67,7 @@ describe Lhm::Throttler::Slave do
         expected_config = {username: 'user', password: 'pw', database: 'db', host: 'slave'}
         Mysql2::Client.stubs(:new).with(expected_config).returns(mock())
 
-        assert Lhm::Throttler::Slave.new('slave', get_config).connection
+        assert Lhm::Throttler::Slave.new('slave', @dummy_mysql_client_config).connection
       end
     end
 
@@ -101,7 +99,7 @@ describe Lhm::Throttler::Slave do
         end
       end
 
-      @slave = Lhm::Throttler::Slave.new('slave', get_config)
+      @slave = Lhm::Throttler::Slave.new('slave', @dummy_mysql_client_config)
       @slave.instance_variable_set(:@connection, Connection)
 
       class StoppedConnection
@@ -110,7 +108,7 @@ describe Lhm::Throttler::Slave do
         end
       end
 
-      @stopped_slave = Lhm::Throttler::Slave.new('stopped_slave', get_config)
+      @stopped_slave = Lhm::Throttler::Slave.new('stopped_slave', @dummy_mysql_client_config)
       @stopped_slave.instance_variable_set(:@connection, StoppedConnection)
     end
 
@@ -139,7 +137,7 @@ describe Lhm::Throttler::Slave do
         Lhm::Throttler::Slave.any_instance.stubs(:client).returns(client)
         Lhm::Throttler::Slave.any_instance.stubs(:config).returns([])
 
-        slave = Lhm::Throttler::Slave.new('slave', get_config)
+        slave = Lhm::Throttler::Slave.new('slave', @dummy_mysql_client_config)
         assert_send([Lhm.logger, :info, "Unable to connect and/or query slave: error"])
         assert_equal(0, slave.lag)
       end
@@ -225,7 +223,7 @@ describe Lhm::Throttler::SlaveLag do
         client.stubs(:query).raises(Mysql2::Error, "Can't connect to MySQL server")
         Lhm::Throttler::Slave.any_instance.stubs(:client).returns(client)
 
-        Lhm::Throttler::Slave.any_instance.stubs(:config).returns([])
+        Lhm::Throttler::Slave.any_instance.stubs(:prepare_connection_config).returns([])
         Lhm::Throttler::Slave.any_instance.stubs(:slave_hosts).returns(['1.1.1.2'])
         @throttler.stubs(:master_slave_hosts).returns(['1.1.1.1'])
 
@@ -252,7 +250,7 @@ describe Lhm::Throttler::SlaveLag do
         class TestSlave
           attr_reader :host, :connection
 
-          def initialize(host, get_config)
+          def initialize(host, _)
             @host = host
             @connection = 'conn' if @host
           end


### PR DESCRIPTION
The Billing team was trying to use the Slave Lag Throttler to run some LHMs and it wasn't behaving as expected. While investigating, we noticed a log statement like: 
"`Connecting to 35.***.***.31 on database:` "
which made us think that the `config` was missing the `database` entry. Turns out it was just the log statement that was incorrect/misleading (`config['database']` vs `config[:database]`).

I am proposing to fix this by symbolizing the keys in the config and using symbols to access the values. 

I added a test and also refactored a couple of the existing tests since the assertions in those tests were not being executed.
