### PR TITLE
Add more exception classes to retry

### DIFF
--- a/lib/lhm/sql_retry.rb
+++ b/lib/lhm/sql_retry.rb
@@ -41,6 +41,10 @@ module Lhm
             /Lock wait timeout exceeded/,
             /Deadlock found when trying to get lock/,
           ],
+          Mysql2::Error::TimeoutError => [
+            /Lock wait timeout exceeded/,
+            /Deadlock found when trying to get lock/,
+          ],
           Exception => [
             /Lock wait timeout exceeded/,
             /Deadlock found when trying to get lock/,


### PR DESCRIPTION
This new exception class popped up. Sadly we have to add it explicitly
because the version of retriable we can use in Shopify doesn't support
checking inheritance. And also sadly, this isn't customizable by consumers
of the gem, so we're doing it here.