### PR TITLE
Update LOCK_WAIT_TIMEOUT_DELTA

### DIFF
--- a/spec/integration/lock_wait_timeout_spec.rb
+++ b/spec/integration/lock_wait_timeout_spec.rb
@@ -10,6 +10,8 @@ describe Lhm do
 
   it 'set_session_lock_wait_timeouts should set the sessions lock wait timeouts to less than the global values by a delta' do
     connection = Lhm.send(:connection)
+    connection.execute('SET GLOBAL innodb_lock_wait_timeout=11')
+    connection.execute('SET GLOBAL lock_wait_timeout=11')
     connection.execute('SET SESSION innodb_lock_wait_timeout=1')
     connection.execute('SET SESSION lock_wait_timeout=1')
 


### PR DESCRIPTION
Per https://github.com/Shopify/lhm/pull/58#issuecomment-429123140

With a `-2` there (lock wait timeout for the lhm session two second below anybody else), it means that in the case of a queue of clients waiting to grab the lock, the lhm client is going to be the one giving up first.

Which is why we had so many issues completing this lhm/ptosc on collects (and it will likely happen again if we had to run another one on that table): Shopify/datastores#2803.

We first decided to add this delta after an incident in 2014, where we were still using the default lock wait timeout for the version of mysql we were using at that time (5.5): One year.

Looking at that from another perspective, between the LHM client getting the lock, instead of regular web/job client, I'd rather have the LHM succeeding: A single web or job worker timing out is no big deal.

It's not like if we are risking all shopify to lock down by increasing this value: That was the case in 2013/2014, where clients waited to acquire the lock forever, not like now, for ten seconds.