### PR TITLE
Improve exception error retry

### DIFF
--- a/lib/lhm/sql_retry.rb
+++ b/lib/lhm/sql_retry.rb
@@ -34,22 +34,7 @@ module Lhm
     # For a full list of configuration options see https://github.com/kamui/retriable
     def default_retry_config
       {
-        on: {
-          ActiveRecord::LockWaitTimeout => nil,
-          ActiveRecord::Deadlocked => nil,
-          Mysql2::Error => [
-            /Lock wait timeout exceeded/,
-            /Deadlock found when trying to get lock/,
-          ],
-          Mysql2::Error::TimeoutError => [
-            /Lock wait timeout exceeded/,
-            /Deadlock found when trying to get lock/,
-          ],
-          Exception => [
-            /Lock wait timeout exceeded/,
-            /Deadlock found when trying to get lock/,
-          ]
-        },
+        on: retry_error_classes,
         multiplier: 1, # each successive interval grows by this factor
         base_interval: 1, # the initial interval in seconds between tries.
         tries: 20, # Number of attempts to make at running your code block (includes initial attempt).
@@ -62,5 +47,33 @@ module Lhm
         end
       }.freeze
     end
+
+    def retry_classes_list
+      {
+        "ActiveRecord::LockWaitTimeout" => nil,
+        "ActiveRecord::Deadlocked" => nil,
+        "Mysql2::Error" => [
+          /Lock wait timeout exceeded/,
+          /Deadlock found when trying to get lock/,
+        ],
+        "Mysql2::Error::TimeoutError" => [
+          /Lock wait timeout exceeded/,
+          /Deadlock found when trying to get lock/,
+        ],
+        "Exception" => [
+          /Lock wait timeout exceeded/,
+          /Deadlock found when trying to get lock/,
+        ]
+      }
+    end
+
+    def retry_error_classes
+      error_classes = Hash.new
+      retry_classes_list.each do |k, v|
+        error_classes[Kernel.const_get(k)] = v
+      end
+      error_classes
+    end
+
   end
 end

--- a/lib/lhm/sql_retry.rb
+++ b/lib/lhm/sql_retry.rb
@@ -52,6 +52,9 @@ module Lhm
       {
         "ActiveRecord::LockWaitTimeout" => nil,
         "ActiveRecord::Deadlocked" => nil,
+        "ActiveRecord::QueryTimedout" => [
+          /Timeout waiting for a response from the last query/,
+        ],
         "Mysql2::Error" => [
           /Lock wait timeout exceeded/,
           /Deadlock found when trying to get lock/,
@@ -70,7 +73,9 @@ module Lhm
     def retry_error_classes
       error_classes = Hash.new
       retry_classes_list.each do |k, v|
-        error_classes[Kernel.const_get(k)] = v
+        if Object.const_defined?(k)
+          error_classes[Kernel.const_get(k)] = v
+        end
       end
       error_classes
     end


### PR DESCRIPTION
This PR adds a new exception class to the list of exceptions on which to retry the LHMs. We also do some cleanup and guard against uninitialized constant, because some of these exception classes might not be initialized in different apps or version of rails.