### PR TITLE
Bump version for new exception class retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.3 (Oct 16, 2018)
+
+* Add ActiveRecord::QueryTimedout exception class to be retried on "Timeout waiting for a response from the last query" message.
+
 # 3.2.2 (Oct 11, 2018)
 
 * Try to take a higher lock_wait_timeout value than others  (https://github.com/Shopify/lhm/pull/60)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lhm (3.2.2)
+    lhm (3.2.3)
       retriable
 
 GEM

--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = '3.2.2'
+  VERSION = '3.2.3'
 end


### PR DESCRIPTION
Bump up the version for LHM and also create a release related to this [patch](https://github.com/Shopify/lhm/pull/63).