### PR TITLE
Add inbound/outbound FK handling

### DIFF
--- a/lib/lhm/chunk_finder.rb
+++ b/lib/lhm/chunk_finder.rb
@@ -22,11 +22,11 @@ module Lhm
     private
 
     def select_start_from_db
-      @connection.select_value("select min(id) from `#{ @migration.origin_name }`")
+      @connection.select_value("select min(#{@migration.origin_pk}) from `#{ @migration.origin_name }`")
     end
 
     def select_limit_from_db
-      @connection.select_value("select max(id) from `#{ @migration.origin_name }`")
+      @connection.select_value("select max(#{@migration.origin_pk}) from `#{ @migration.origin_name }`")
     end
   end
 end

--- a/lib/lhm/chunk_insert.rb
+++ b/lib/lhm/chunk_insert.rb
@@ -24,7 +24,7 @@ module Lhm
     def sql
       "insert ignore into `#{ @migration.destination_name }` (#{ @migration.destination_columns }) " \
       "select #{ @migration.origin_columns } from `#{ @migration.origin_name }` " \
-      "#{ conditions } `#{ @migration.origin_name }`.`id` between #{ @lowest } and #{ @highest }"
+      "#{ conditions } `#{ @migration.origin_name }`.`#{@migration.origin_pk}` between #{ @lowest } and #{ @highest }"
     end
 
     private

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -51,7 +51,9 @@ module Lhm
     end
 
     def upper_id(next_id, stride)
-      top = connection.select_value("select id from `#{ @migration.origin_name }` where id >= #{ next_id } order by id limit 1 offset #{ stride - 1}")
+      pk = @migration.origin_pk
+
+      top = connection.select_value("select #{ pk } from `#{ @migration.origin_name }` where #{ pk } >= #{ next_id } order by #{ pk } limit 1 offset #{ stride - 1}")
       [top ? top.to_i : @limit, @limit].min
     end
 

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -66,7 +66,7 @@ module Lhm
         create trigger `#{ trigger(:del) }`
         after delete on `#{ @origin.name }` for each row
         delete ignore from `#{ @destination.name }` #{ SqlHelper.annotation }
-        where `#{ @destination.name }`.`id` = OLD.`id`
+        where `#{ @destination.name }`.`#{ @destination.pk }` = OLD.`#{ @origin.pk }`
       }
     end
 

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -54,6 +54,8 @@ module Lhm
       entangler.run do
         Chunker.new(migration, @connection, options).run
         raise "Required triggers do not exist" unless triggers_still_exist?(entangler)
+
+        @migrator.before_switch
         if options[:atomic_switch]
           AtomicSwitcher.new(migration, @connection).run
         else

--- a/lib/lhm/migration.rb
+++ b/lib/lhm/migration.rb
@@ -24,6 +24,10 @@ module Lhm
       Intersection.new(@origin, @destination, @renames)
     end
 
+    def origin_pk
+      @origin_pk ||= origin.pk
+    end
+
     def origin_name
       @table_name.original
     end

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -187,7 +187,7 @@ module Lhm
         error("could not find origin table #{ @origin.name }")
       end
 
-      unless @origin.satisfies_id_column_requirement?
+      unless @origin.satisfies_pk_requirement?
         error('origin does not satisfy `id` key requirements')
       end
 

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -207,9 +207,7 @@ module Lhm
     end
 
     def destination_create
-      original    = %{CREATE TABLE `#{ @origin.name }`}
-      replacement = %{CREATE TABLE `#{ @origin.destination_name }`}
-      stmt = @origin.ddl.gsub(original, replacement)
+      stmt = @origin.destination_ddl
       @connection.execute(tagged(stmt))
     end
 

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -191,6 +191,11 @@ module Lhm
         error('origin does not satisfy `id` key requirements')
       end
 
+      unless @origin.satisfies_references_column_requirement?
+        tables = @origin.references.map{|a| "#{a['table_name']}:#{a['constraint_name']}"}.join(', ')
+        error("foreign key constraint fails for tables (#{tables}); before running LHM migration you need to drop this foreign keys;")
+      end
+
       dest = @origin.destination_name
 
       if @connection.data_source_exists?(dest)

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -5,15 +5,17 @@ require 'lhm/sql_helper'
 
 module Lhm
   class Table
-    attr_reader :name, :columns, :indices, :pk, :ddl
+    attr_reader :name, :columns, :indices, :pk, :ddl, :schema, :constraints
 
-    def initialize(name, pk = 'id', ddl = nil)
+    def initialize(name, pk = 'id', ddl = nil, schema = 'default')
       @name = name
       @table_name = TableName.new(name)
       @columns = {}
       @indices = {}
       @pk = pk
       @ddl = ddl
+      @schema = schema
+      @constraints = {}
     end
 
     def satisfies_pk_requirement?
@@ -24,8 +26,33 @@ module Lhm
       @destination_name ||= @table_name.new
     end
 
+    def destination_ddl
+      original    = /CREATE TABLE ("|`)#{ name }\1/
+      repl = '\1'
+      replacement = %Q{CREATE TABLE #{ repl }#{ destination_name }#{ repl }}
+      dest = ddl
+      dest.gsub!(original, replacement)
+
+      foreign_keys = constraints.reject { |col, c| c[:referenced_column].nil? }
+
+      foreign_keys.keys.each_with_index do |key, i|
+        original = foreign_keys[key][:name]
+        replacement = replacement_constraint(original)
+        dest.gsub!(original, replacement)
+      end
+
+      dest
+    end
+
     def self.parse(table_name, connection)
       Parser.new(table_name, connection).parse
+    end
+
+    @@schema_constraints = {}
+
+    def self.schema_constraints(schema, value = nil)
+      @@schema_constraints[schema] = value if value
+      @@schema_constraints[schema]
     end
 
     class Parser
@@ -47,7 +74,7 @@ module Lhm
       def parse
         schema = read_information_schema
 
-        Table.new(@table_name, extract_primary_key(schema), ddl).tap do |table|
+        Table.new(@table_name, extract_primary_key(schema), ddl, @schema_name).tap do |table|
           schema.each do |defn|
             column_name    = struct_key(defn, 'COLUMN_NAME')
             column_type    = struct_key(defn, 'COLUMN_TYPE')
@@ -64,6 +91,17 @@ module Lhm
           extract_indices(read_indices).each do |idx, columns|
             table.indices[idx] = columns
           end
+
+          constraints = {}
+          extract_constraints(read_constraints).each do |data|
+            if data[:schema] == @schema_name && data[:table] == @table_name
+              table.constraints[data[:column]] = data
+            end
+
+            constraints[data[:name]] = data
+          end
+
+          Table.schema_constraints(@schema_name, constraints)
         end
       end
 
@@ -98,6 +136,53 @@ module Lhm
           end
       end
 
+      def read_constraints
+        query = %Q{
+          select *
+            from information_schema.key_column_usage
+          where table_schema = '#{@schema_name}'
+            and referenced_column_name is not null
+        }
+
+        if @table_name
+          query += %Q{
+            and table_name = '#{@table_name}'
+          }
+        end
+
+        @connection.select_all(query)
+      end
+
+      def extract_constraints(constraints)
+        columns = %w{
+          CONSTRAINT_NAME
+          TABLE_SCHEMA
+          TABLE_NAME
+          COLUMN_NAME
+          ORDINAL_POSITION
+          POSITION_IN_UNIQUE_CONSTRAINT
+          REFERENCED_TABLE_SCHEMA
+          REFERENCED_TABLE_NAME
+          REFERENCED_COLUMN_NAME
+        }
+
+        constraints.map do |row|
+          result = {}
+
+          columns.each do |c|
+            sym = c.dup
+
+            sym.gsub!(/CONSTRAINT_/, '')
+            sym.gsub!(/_NAME/, '')
+            sym.gsub!(/TABLE_/, '')
+
+            result[sym.downcase.to_sym] = row[struct_key(row, c)]
+          end
+
+          result
+        end
+      end
+
       def extract_primary_key(schema)
         cols = schema.select do |defn|
           column_key = struct_key(defn, 'COLUMN_KEY')
@@ -111,6 +196,10 @@ module Lhm
 
         keys.length == 1 ? keys.first : keys
       end
+    end
+
+    def replacement_constraint(name)
+      (name =~ /_lhmn$/).nil? ? "#{name}_lhmn" : name.gsub(/_lhmn$/, '')
     end
   end
 end

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -16,9 +16,8 @@ module Lhm
       @ddl = ddl
     end
 
-    def satisfies_id_column_requirement?
-      !!((id = columns['id']) &&
-        id[:type] =~ /(bigint|int)\(\d+\)/)
+    def satisfies_pk_requirement?
+      @pk.is_a?(String) && !!(columns[@pk][:type] =~ /int\(\d+\)/)
     end
 
     def destination_name

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -22,10 +22,6 @@ module Lhm
       @pk.is_a?(String) && !!(columns[@pk][:type] =~ /int\(\d+\)/)
     end
 
-    def satisfies_references_column_requirement?
-        !references.any?
-    end
-
     def destination_name
       @destination_name ||= @table_name.new
     end
@@ -133,7 +129,7 @@ module Lhm
 
       def read_references
           @connection.select_all %Q{
-          select constraint_name,table_name, table_schema, column_name
+          select constraint_name, table_name, table_schema, column_name, referenced_column_name
             from information_schema.key_column_usage
           where referenced_table_name = '#{ @table_name }'
             and referenced_table_schema = '#{ @schema_name }'

--- a/spec/fixtures/fk_child_table.ddl
+++ b/spec/fixtures/fk_child_table.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `fk_child_table` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `origin_table_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_origin_table_id` FOREIGN KEY (`origin_table_id`) REFERENCES `origin_example` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/fk_example.ddl
+++ b/spec/fixtures/fk_example.ddl
@@ -1,0 +1,8 @@
+CREATE TABLE `fk_example` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `master_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_example_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_example_ibfk_2` FOREIGN KEY (`master_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/fk_example_second_pass.ddl
+++ b/spec/fixtures/fk_example_second_pass.ddl
@@ -1,0 +1,8 @@
+CREATE TABLE `fk_example_second_pass` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `master_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_example_ibfk_1_lhmn` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_example_ibfk_2_lhmn` FOREIGN KEY (`master_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/origin_example.ddl
+++ b/spec/fixtures/origin_example.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `origin_example` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `master_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/primary_keys.ddl
+++ b/spec/fixtures/primary_keys.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `primary_keys` (
+  `weird_id` int(11) NOT NULL AUTO_INCREMENT,
+  `origin` int(11) DEFAULT NULL,
+  `common` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`weird_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/integration/foreign_keys_spec.rb
+++ b/spec/integration/foreign_keys_spec.rb
@@ -1,0 +1,89 @@
+# Copyright (c) 2011 - 2013, SoundCloud Ltd., Rany Keddo, Tobias Bielohlawek, Tobias
+# Schmidt
+
+require File.expand_path(File.dirname(__FILE__)) + '/integration_helper'
+
+require 'lhm'
+
+describe Lhm do
+  include IntegrationHelper
+
+  before(:each) do
+    connect_master!
+    Lhm.cleanup(true)
+    %w(fk_example fk_example_second_pass).each do |table|
+      execute "drop table if exists #{table}"
+    end
+    table_create(:users)
+  end
+
+  describe 'the simplest case' do
+    before(:each) do
+      table_create(:fk_example)
+    end
+
+    after(:each) do
+      execute 'drop table if exists fk_example'
+      Lhm.cleanup(true)
+    end
+
+    it 'should handle tables with foreign keys by appending the suffix' do
+      Lhm.change_table(:fk_example) do |t|
+        t.add_column(:new_column, "INT(12) DEFAULT '0'")
+      end
+
+      slave do
+        actual = table_read(:fk_example).constraints['user_id']
+        expected = {
+            name: 'fk_example_ibfk_1_lhmn',
+            referenced_table: 'users',
+            referenced_column: 'id',
+        }
+        hash_slice(actual, expected.keys).must_equal(expected)
+
+        actual = table_read(:fk_example).constraints['master_id']
+        expected = {
+            name: 'fk_example_ibfk_2_lhmn',
+            referenced_table: 'users',
+            referenced_column: 'id',
+        }
+        hash_slice(actual, expected.keys).must_equal(expected)
+      end
+    end
+  end
+
+  describe 'manage a new migration by removing the suffix' do
+    before(:each) do
+      table_create(:fk_example_second_pass)
+    end
+
+    after(:each) do
+      execute 'drop table if exists fk_example_second_pass'
+      Lhm.cleanup(true)
+    end
+
+    it 'should be able to create this table' do
+      Lhm.change_table(:fk_example_second_pass) do |t|
+        t.add_column(:new_column, "INT(12) DEFAULT '0'")
+      end
+
+      slave do
+        actual = table_read(:fk_example_second_pass).constraints['user_id']
+        expected = {
+            name: 'fk_example_ibfk_1',
+            referenced_table: 'users',
+            referenced_column: 'id',
+        }
+        hash_slice(actual, expected.keys).must_equal(expected)
+
+        actual = table_read(:fk_example_second_pass).constraints['master_id']
+        expected = {
+            name: 'fk_example_ibfk_2',
+            referenced_table: 'users',
+            referenced_column: 'id',
+        }
+        hash_slice(actual, expected.keys).must_equal(expected)
+      end
+    end
+  end
+end

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -167,6 +167,11 @@ module IntegrationHelper
     )
   end
 
+  def hash_slice(hash, keys)
+    return hash.slice(*keys) if hash.respond_to?(:slice)
+    keys.each { |k| [k, hash[k]] }.to_h
+  end
+
   #
   # Database Helpers
   #

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -25,21 +25,23 @@ describe Lhm do
       end
     end
 
-    it 'should migrate the table when id is not pk' do
-      table_create(:custom_primary_key)
-
-      Lhm.change_table(:custom_primary_key, :atomic_switch => false) do |t|
-        t.add_column(:logins, "int(12) default '0'")
-      end
-
-      slave do
-        table_read(:custom_primary_key).columns['logins'].must_equal({
-          :type           => 'int(12)',
-          :is_nullable    => 'YES',
-          :column_default => '0',
-        })
-      end
-    end
+    # TODO(bunea): Add order_column support
+    #
+    # it 'should migrate the table when id is not pk' do
+    #   table_create(:custom_primary_key)
+    #
+    #   Lhm.change_table(:custom_primary_key, :atomic_switch => false) do |t|
+    #     t.add_column(:logins, "int(12) default '0'")
+    #   end
+    #
+    #   slave do
+    #     table_read(:custom_primary_key).columns['logins'].must_equal({
+    #       :type           => 'int(12)',
+    #       :is_nullable    => 'YES',
+    #       :column_default => '0',
+    #     })
+    #   end
+    # end
   end
 
   describe 'changes' do
@@ -391,6 +393,22 @@ describe Lhm do
 
         slave do
           count_all(:users).must_equal(40)
+        end
+      end
+
+      it 'should change a table with a primary key other than id' do
+        table_create(:primary_keys)
+
+        Lhm.change_table(:primary_keys, :atomic_switch => false) do |t|
+          t.change_column(:weird_id, "int(5)")
+        end
+
+        slave do
+          table_read(:primary_keys).columns['weird_id'].must_equal({
+              :type => "int(5)",
+              :is_nullable => "NO",
+              :column_default => nil
+           })
         end
       end
     end

--- a/spec/integration/references_spec.rb
+++ b/spec/integration/references_spec.rb
@@ -1,0 +1,65 @@
+# Copyright (c) 2011 - 2013, SoundCloud Ltd., Rany Keddo, Tobias Bielohlawek, Tobias
+# Schmidt
+
+require File.expand_path(File.dirname(__FILE__)) + '/integration_helper'
+
+require 'lhm'
+
+describe Lhm do
+  include IntegrationHelper
+
+
+    describe 'the simplest case' do
+      before(:each) do
+        connect_master!
+        Lhm.cleanup(true)
+        %w(fk_child_table origin_example).each do |table|
+          execute "drop table if exists #{table}"
+        end
+        %w(origin_example fk_child_table).each do |table|
+          execute "drop table if exists `fk_child_table`"
+          table_create(table)
+      end
+    end
+
+    after(:each) do
+      Lhm.cleanup(true)
+    end
+
+    it 'should show the foreign key constraints for given table' do
+      actual = table_read(:origin_example).references
+      expected = [{
+        "constraint_name"=> "fk_origin_table_id",
+        "table_name"=> "fk_child_table",
+        "table_schema"=> "test",
+        "column_name"=> "origin_table_id"
+        }]
+      actual.must_equal(expected)
+    end
+
+    it 'should raise an exception for foreign key constraint fails for referencing tables' do
+      exception = assert_raises(Exception) {
+        Lhm.change_table(:origin_example) do |t|
+          t.add_column(:new_column, "INT(12) DEFAULT '0'")
+        end
+      }
+      references = table_read(:origin_example).references
+      tables = references.map{|a| "#{a['table_name']}:#{a['constraint_name']}"}.join(', ')
+      message = "foreign key constraint fails for tables (#{tables}); before running LHM migration you need to drop this foreign keys;"
+      assert_equal(message, exception.message )
+    end
+
+    it 'should add a column after droping foreign key constraints' do
+      execute "alter table `fk_child_table` drop foreign key `fk_origin_table_id`"
+      Lhm.change_table(:origin_example) do |t|
+        t.add_column(:new_column, "INT(12) DEFAULT '0'")
+      end
+      connect_master!
+      table_read(:origin_example).columns['new_column'].must_equal({
+        :type => 'int(12)',
+        :is_nullable => 'YES',
+        :column_default => '0',
+      })
+    end
+  end
+end

--- a/spec/integration/table_spec.rb
+++ b/spec/integration/table_spec.rb
@@ -88,6 +88,21 @@ describe Lhm::Table do
           indices['index_users_on_reference'].
           must_equal(['reference'])
       end
+
+      it 'should parse constraints' do
+        begin
+          @table = table_create(:fk_example)
+          @table.constraints.keys.must_equal %w(user_id master_id)
+          expected = {
+              name: 'fk_example_ibfk_1',
+              referenced_table: 'users',
+              referenced_column: 'id'
+          }
+          hash_slice(@table.constraints['user_id'], expected.keys).must_equal expected
+        ensure
+          execute 'drop table if exists fk_example'
+        end
+      end
     end
   end
 end

--- a/spec/integration/table_spec.rb
+++ b/spec/integration/table_spec.rb
@@ -7,50 +7,52 @@ require 'lhm/table'
 describe Lhm::Table do
   include IntegrationHelper
 
-  describe 'id numeric column requirement' do
-    describe 'when met' do
-      before(:each) do
-        connect_master!
-        @table = table_create(:custom_primary_key)
-      end
-
-      it 'should parse primary key' do
-        @table.pk.must_equal('pk')
-      end
-
-      it 'should parse indices' do
-        @table.
-          indices['index_custom_primary_key_on_id'].
-          must_equal(['id'])
-      end
-
-      it 'should parse columns' do
-        @table.
-          columns['id'][:type].
-          must_match(/(bigint|int)\(\d+\)/)
-      end
-
-      it 'should return true for method that should be renamed' do
-        @table.satisfies_id_column_requirement?.must_equal true
-      end
-
-      it 'should support bigint tables' do
-        @table = table_create(:bigint_table)
-        @table.satisfies_id_column_requirement?.must_equal true
-      end
-    end
-
-    describe 'when not met' do
-      before(:each) do
-        connect_master!
-      end
-
-      it 'should return false for a non-int id column' do
-        @table = table_create(:wo_id_int_column)
-        @table.satisfies_id_column_requirement?.must_equal false
-      end
-    end
-  end
+  # TODO(bunea): Add order_column support
+  #
+  # describe 'id numeric column requirement' do
+  #   describe 'when met' do
+  #     before(:each) do
+  #       connect_master!
+  #       @table = table_create(:custom_primary_key)
+  #     end
+  #
+  #     it 'should parse primary key' do
+  #       @table.pk.must_equal('pk')
+  #     end
+  #
+  #     it 'should parse indices' do
+  #       @table.
+  #         indices['index_custom_primary_key_on_id'].
+  #         must_equal(['id'])
+  #     end
+  #
+  #     it 'should parse columns' do
+  #       @table.
+  #         columns['id'][:type].
+  #         must_match(/int\(\d+\)/)
+  #     end
+  #
+  #     it 'should return true for method that should be renamed' do
+  #       @table.satisfies_pk_requirement?.must_equal true
+  #     end
+  #
+  #     it 'should support bigint tables' do
+  #       @table = table_create(:bigint_table)
+  #       @table.satisfies_pk_requirement?.must_equal true
+  #     end
+  #   end
+  #
+  #   describe 'when not met' do
+  #     before(:each) do
+  #       connect_master!
+  #     end
+  #
+  #     it 'should return false for a non-int id column' do
+  #       @table = table_create(:wo_id_int_column)
+  #       @table.satisfies_pk_requirement?.must_equal false
+  #     end
+  #   end
+  # end
 
   describe Lhm::Table::Parser do
     describe 'create table parsing' do

--- a/spec/unit/chunk_insert_spec.rb
+++ b/spec/unit/chunk_insert_spec.rb
@@ -40,5 +40,20 @@ describe Lhm::ChunkInsert do
         )
       end
     end
+
+    describe "when primary key is not id" do
+      before do
+        @origin = Lhm::Table.new('foo', 'foo_id')
+        @destination = Lhm::Table.new('bar', 'foo_id')
+        @migration = Lhm::Migration.new(@origin, @destination)
+      end
+
+      it "works with primary key not called id" do
+        assert_equal(
+          Lhm::ChunkInsert.new(@migration, @connection, 1, 2).sql,
+          "insert ignore into `bar` () select  from `foo` where `foo`.`foo_id` between 1 and 2"
+        )
+      end
+    end
   end
 end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -23,19 +23,25 @@ describe Lhm::Table do
     it 'should be satisfied with a single column primary key called id' do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'int(1)' } })
-      @table.satisfies_id_column_requirement?.must_equal true
-    end
-
-    it 'should be satisfied with a primary key not called id, as long as there is still an id' do
-      @table = Lhm::Table.new('table', 'uuid')
-      set_columns(@table, { 'id' => { :type => 'int(1)' } })
-      @table.satisfies_id_column_requirement?.must_equal true
+      @table.satisfies_pk_requirement?.must_equal true
     end
 
     it 'should not be satisfied if id is not numeric' do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'varchar(255)' } })
-      @table.satisfies_id_column_requirement?.must_equal false
+      @table.satisfies_pk_requirement?.must_equal false
+    end
+
+    it 'should be satisfied if primary key is not called id' do
+      @table = Lhm::Table.new('table', 'user_id')
+      set_columns(@table, { 'user_id' => { :type => 'int(1)' } })
+      @table.satisfies_pk_requirement?.must_equal true
+    end
+
+    it 'should not be satisfied with a non numeric primary key' do
+      @table = Lhm::Table.new('table', 'user_id')
+      set_columns(@table, { 'user_id' => { :type => 'varchar(255)' } })
+      @table.satisfies_pk_requirement?.must_equal false
     end
   end
 end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -35,7 +35,6 @@ describe Lhm::Table do
       table.instance_variable_set('@references', references)
     end
 
-
     it 'should be satisfied with a single column primary key called id' do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'int(1)' } })
@@ -59,18 +58,5 @@ describe Lhm::Table do
       set_columns(@table, { 'user_id' => { :type => 'varchar(255)' } })
       @table.satisfies_pk_requirement?.must_equal false
     end
-
-    it 'should be satisfied if origin table not refer by any other table using foreign key' do
-      @table = Lhm::Table.new('table')
-      set_references(@table, [])
-      @table.satisfies_references_column_requirement?.must_equal true
-    end
-
-    it 'should NOT be satisfied if origin table refer by any other table using foreign key' do
-      @table = Lhm::Table.new('table', 'id')
-      set_references(@table, [{"CONSTRAINT_NAME"=>"fk_rails_40ebb3948d", "TABLE_NAME"=>"child_table", "TABLE_SCHEMA"=>"schema", "COLUMN_NAME"=>"table_id"}])
-      @table.satisfies_references_column_requirement?.must_equal false
-    end
-
   end
 end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -31,6 +31,11 @@ describe Lhm::Table do
       table.instance_variable_set('@columns', columns)
     end
 
+    def set_references(table, references)
+      table.instance_variable_set('@references', references)
+    end
+
+
     it 'should be satisfied with a single column primary key called id' do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'int(1)' } })
@@ -54,5 +59,18 @@ describe Lhm::Table do
       set_columns(@table, { 'user_id' => { :type => 'varchar(255)' } })
       @table.satisfies_pk_requirement?.must_equal false
     end
+
+    it 'should be satisfied if origin table not refer by any other table using foreign key' do
+      @table = Lhm::Table.new('table')
+      set_references(@table, [])
+      @table.satisfies_references_column_requirement?.must_equal true
+    end
+
+    it 'should NOT be satisfied if origin table refer by any other table using foreign key' do
+      @table = Lhm::Table.new('table', 'id')
+      set_references(@table, [{"CONSTRAINT_NAME"=>"fk_rails_40ebb3948d", "TABLE_NAME"=>"child_table", "TABLE_SCHEMA"=>"schema", "COLUMN_NAME"=>"table_id"}])
+      @table.satisfies_references_column_requirement?.must_equal false
+    end
+
   end
 end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -8,6 +8,17 @@ require 'lhm/table'
 describe Lhm::Table do
   include UnitHelper
 
+  describe 'ddl' do
+    it 'should build the destination table' do
+      table = 'users'
+      schema = 'default'
+      @table = Lhm::Table.new(table, 'id', %Q{CREATE TABLE `#{table}` (random_constraint)}, schema)
+      @table.constraints['user_id'] = {:name => 'random_constraint', :referenced_column => true}
+      Lhm::Table.schema_constraints(schema, {'random_constraint_lhmn' => true})
+      @table.destination_ddl.must_equal %Q{CREATE TABLE `#{@table.destination_name}` (random_constraint_lhmn)}
+    end
+  end
+
   describe 'names' do
     it 'should name destination' do
       @table = Lhm::Table.new('users')


### PR DESCRIPTION
Improvements in this PR:
- copy outbound foreign keys to the newly created table
- updates inbound foreign key reference to the newly created table before the switch
- remove name restriction from primary keys