### PR TITLE
Simplify LHM exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.5 (Jun 24, 2019)
+
+* Tighten dependency on retriable gem and remove workarounds for old version
+
 # 3.2.4 (Oct 16, 2018)
 
 * Retry `Cleanup::Current` just like we retry all the other DDLs.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lhm (3.2.4)
+    lhm (3.2.5)
       retriable (>= 3.0.0)
 
 GEM
@@ -80,4 +80,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     lhm (3.2.4)
-      retriable
+      retriable (>= 3.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lhm.gemspec
+++ b/lhm.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_dependency 'retriable'
+  s.add_dependency 'retriable', '>= 3.0.0'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'

--- a/lib/lhm/sql_retry.rb
+++ b/lib/lhm/sql_retry.rb
@@ -34,7 +34,13 @@ module Lhm
     # For a full list of configuration options see https://github.com/kamui/retriable
     def default_retry_config
       {
-        on: retry_error_classes,
+        on: {
+          StandardError => [
+            /Lock wait timeout exceeded/,
+            /Timeout waiting for a response from the last query/,
+            /Deadlock found when trying to get lock/,
+          ]
+        },
         multiplier: 1, # each successive interval grows by this factor
         base_interval: 1, # the initial interval in seconds between tries.
         tries: 20, # Number of attempts to make at running your code block (includes initial attempt).
@@ -47,38 +53,5 @@ module Lhm
         end
       }.freeze
     end
-
-    def retry_classes_list
-      {
-        "ActiveRecord::LockWaitTimeout" => nil,
-        "ActiveRecord::Deadlocked" => nil,
-        "ActiveRecord::QueryTimedout" => [
-          /Timeout waiting for a response from the last query/,
-        ],
-        "Mysql2::Error" => [
-          /Lock wait timeout exceeded/,
-          /Deadlock found when trying to get lock/,
-        ],
-        "Mysql2::Error::TimeoutError" => [
-          /Lock wait timeout exceeded/,
-          /Deadlock found when trying to get lock/,
-        ],
-        "Exception" => [
-          /Lock wait timeout exceeded/,
-          /Deadlock found when trying to get lock/,
-        ]
-      }
-    end
-
-    def retry_error_classes
-      error_classes = Hash.new
-      retry_classes_list.each do |k, v|
-        if Object.const_defined?(k)
-          error_classes[Kernel.const_get(k)] = v
-        end
-      end
-      error_classes
-    end
-
   end
 end

--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = '3.2.4'
+  VERSION = '3.2.5'
 end


### PR DESCRIPTION
Now that we can confidently rely on `retriable > 3` we can remove the logic which checks if an exception is defined etc. and go back to matching on `StandardError` subclasses, by the text of the exception instead.

This will return the gem to being Rails agnostic and not relying on specific wrapped exceptions that other users may not have in their Rails apps.