### PR TITLE
Abort LHM early when triggers are removed during a copy

### DIFF
--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -19,6 +19,7 @@ module Lhm
       @migration = migration
       @connection = connection
       @chunk_finder = ChunkFinder.new(migration, connection, options)
+      @verifier = options[:verifier]
       if @throttler = options[:throttler]
         @throttler.connection = @connection if @throttler.respond_to?(:connection=)
       end
@@ -33,6 +34,9 @@ module Lhm
       while @next_to_insert <= @limit || (@start == @limit)
         stride = @throttler.stride
         top = upper_id(@next_to_insert, stride)
+        if @verifier && !@verifier.call
+          raise "Verification failed, aborting early"
+        end
         affected_rows = ChunkInsert.new(@migration, @connection, bottom, top).insert_and_return_count_of_rows_created
         if @throttler && affected_rows > 0
           @throttler.run

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -52,6 +52,7 @@ module Lhm
       entangler = Entangler.new(migration, @connection, options)
 
       entangler.run do
+        options[:verifier] = Proc.new { triggers_still_exist?(entangler) }
         Chunker.new(migration, @connection, options).run
         raise "Required triggers do not exist" unless triggers_still_exist?(entangler)
         if options[:atomic_switch]

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -52,7 +52,7 @@ module Lhm
       entangler = Entangler.new(migration, @connection, options)
 
       entangler.run do
-        options[:verifier] = Proc.new { triggers_still_exist?(entangler) }
+        options[:verifier] ||= Proc.new { triggers_still_exist?(entangler) }
         Chunker.new(migration, @connection, options).run
         raise "Required triggers do not exist" unless triggers_still_exist?(entangler)
         if options[:atomic_switch]

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -296,7 +296,7 @@ describe Lhm do
         end
       end
 
-      assert_match "Required triggers do not exist", exception.message
+      assert_match "Verification failed, aborting early", exception.message
     end
 
     it 'should not perform the table rename if the triggers do not exist after copying all rows' do


### PR DESCRIPTION
It's not safe to perform the last step of LHM (the rename) if the triggers have been removed. Thankfully, this fork of LHM will avoid data corruption, thanks to https://github.com/Shopify/lhm/pull/23

However, we still _run_ the LHM to completion before giving up. This PR adds a `verifier` to options which can be used to check if LHM should continue to insert rows. This should result in less wasted work when triggers are dropped, with the side effect that LHM can be convinced to abort by manually dropping the triggers or by running `cleanup`.