### PR TITLE
LHM printer.notify(current_pk, max_pk, {bytes_copied: ..., total_bytes: ..., copy_speed: ...})

### DIFF
--- a/lib/lhm/printer.rb
+++ b/lib/lhm/printer.rb
@@ -18,9 +18,9 @@ module Lhm
         @max_length = 0
       end
 
-      def notify(lowest, highest)
-        return if !highest || highest == 0
-        message = "%.2f%% (#{lowest}/#{highest}) complete" % (lowest.to_f / highest * 100.0)
+      def notify(current_pk, max_pk, additional_info = {})
+        return if !max_pk || max_pk == 0
+        message = "%.2f%% (#{current_pk}/#{max_pk}) complete" % (current_pk.to_f / max_pk * 100.0)
         write(message)
       end
 

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -51,7 +51,7 @@ describe Lhm::Chunker do
       23.times { |n| execute("insert into origin set id = '#{ n * n + 23 }'") }
 
       printer = MiniTest::Mock.new
-      printer.expect(:notify, :return_value, [Integer, Integer])
+      printer.expect(:notify, :return_value, [Integer, Integer, Hash])
       printer.expect(:end, :return_value, [])
 
       Lhm::Chunker.new(
@@ -88,7 +88,7 @@ describe Lhm::Chunker do
       23.times { |n| execute("insert into origin set id = '#{ 100000 + n * n + 23 }'") }
 
       printer = MiniTest::Mock.new
-      printer.expect(:notify, :return_value, [Integer, Integer])
+      printer.expect(:notify, :return_value, [Integer, Integer, Hash])
       printer.expect(:end, :return_value, [])
 
       Lhm::Chunker.new(
@@ -106,7 +106,7 @@ describe Lhm::Chunker do
       15.times { |n| execute("insert into origin set id = '#{ (n * n) + 1 }'") }
 
       printer = mock()
-      printer.expects(:notify).with(instance_of(Integer), instance_of(Integer)).twice
+      printer.expects(:notify).with(instance_of(Integer), instance_of(Integer), instance_of(Hash)).twice
       printer.expects(:end)
 
       throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0)
@@ -129,7 +129,7 @@ describe Lhm::Chunker do
       15.times { |n| execute("insert into origin set id = '#{ (n * n) + 1 }'") }
 
       printer = mock()
-      printer.expects(:notify).with(instance_of(Integer), instance_of(Integer)).twice
+      printer.expects(:notify).with(instance_of(Integer), instance_of(Integer), instance_of(Hash)).twice
       printer.expects(:verify)
       printer.expects(:end)
 


### PR DESCRIPTION
Using the primary key to track progress works very poorly if the PKs are non-uniformly distributed.

This PR changes the `printer.notify` interface to emit three more numbers: 

1. Number of bytes copied in the `lhmn_` table given by `information_schemas.TABLES`. This is the `bytes_copied` parameter.
2. Number of bytes in the original table given by `information_schema.TABLES`. This is the `total_bytes` parameter.
3. The current speed of copy as estimated via linear regression with the aforementioned numbers over the last X minutes.

We should be able to use this to get a more accurate progress/ETA, although if the chunker loop can block for ~1 hr, the accuracy remains doubtful. Additionally, there is a possibility that the addition/removal of a column/index will drastically alter the size of the table, which may make the progress in accurate. Example: if the data increases by 20% after a LHM, the progress will get to a maximum of 80%. Conversely, if the data decreases by 20% after a LHM, the progress will get to a maximum of 120%.

Test coverage of the printer interface is not great. That said the speed calculation does have some basic tests.