### PR TITLE
Retry on 'Unknown MySQL server host' errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lhm (3.3.1)
+    lhm (3.3.2)
       retriable (>= 3.0.0)
 
 GEM

--- a/lib/lhm/sql_retry.rb
+++ b/lib/lhm/sql_retry.rb
@@ -42,6 +42,7 @@ module Lhm
             /Query execution was interrupted/,
             /Lost connection to MySQL server during query/,
             /Max connect timeout reached/,
+            /Unknown MySQL server host/,
           ]
         },
         multiplier: 1, # each successive interval grows by this factor

--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = '3.3.1'
+  VERSION = '3.3.2'
 end


### PR DESCRIPTION
Consider that `Unknown MySQL server host` errors may be transient due to transient DNS or networking errors, so retry them, as odd as that sounds.