### PR TITLE
Add `exception` method to default printer

### DIFF
--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -52,6 +52,9 @@ module Lhm
         break if @start == @limit
       end
       @printer.end
+    rescue => e
+      @printer.exception(e) if @printer.respond_to?(:exception)
+      raise
     end
 
     private

--- a/lib/lhm/printer.rb
+++ b/lib/lhm/printer.rb
@@ -29,6 +29,11 @@ module Lhm
         @output.write "\n"
       end
 
+      def exception(e)
+        write("failed: #{e}")
+        @output.write "\n"
+      end
+
       private
 
       def write(message)

--- a/spec/unit/printer_spec.rb
+++ b/spec/unit/printer_spec.rb
@@ -60,6 +60,19 @@ describe Lhm::Printer do
 
       mock.verify
     end
+
+    it 'prints the exception message' do
+      mock = MiniTest::Mock.new
+      mock.expect(:write, :return_value, ["\rfailed: woops"])
+      mock.expect(:write, :return_value, ["\n"])
+
+      e = StandardError.new('woops')
+
+      @printer.instance_variable_set(:@output, mock)
+      @printer.exception(e)
+
+      mock.verify
+    end
   end
 
   describe 'dot printer' do


### PR DESCRIPTION
Injecting a custom printer is useful to notify, for example, slack. I added a new method to notify the printer of exceptions that happen during execution, so we can also notify on those.