### PR TITLE
Threads Running Throttler

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,24 @@ Or to set that as default throttler, use the following (for instance in a Rails 
 Lhm.setup_throttler(:slave_lag_throttler)
 ```
 
+### ThreadsRunning Throttler
+
+If you don't have access to connect directly to your replicas, you can also
+throttle based on the number of threads running in MySQL, as a proxy for "is
+this operation causing excessive load":
+
+```ruby
+Lhm.change_table :users, throttler: :threads_running_throttler do |m|
+  ...
+end
+```
+
+Or to set that as default throttler, use the following (for instance in a Rails initializer):
+
+```ruby
+Lhm.setup_throttler(:threads_running_throttler)
+```
+
 ## Table rename strategies
 
 There are two different table rename strategies available: `LockedSwitcher` and

--- a/dbdeployer/install.sh
+++ b/dbdeployer/install.sh
@@ -12,8 +12,8 @@ fi
 echo "Checking if dbdeployer is installed"
 if ! [ -x "$(command -v ./bin/dbdeployer)" ]; then
   echo "Not installed...starting install"
-  VERSION=1.8.0
-  origin=https://github.com/datacharmer/dbdeployer/releases/download/$VERSION
+  VERSION=1.56.0
+  origin=https://github.com/datacharmer/dbdeployer/releases/download/v$VERSION
   filename=dbdeployer-$VERSION.$OS
   wget -q $origin/$filename.tar.gz
   tar -xzf $filename.tar.gz

--- a/dev.yml
+++ b/dev.yml
@@ -9,7 +9,7 @@ up:
   - bundler
   - custom:
       name: Database
-      met?: test -f spec/integration/database.yml && test "$(./dbdeployer/sandboxes/rsandbox_5_7_22/status_all | grep on  | wc -l | xargs echo)" = "2"
+      met?: test -f spec/integration/database.yml && test "$(./dbdeployer/sandboxes/rsandbox_5_7_22/status_all | grep on\  | wc -l | xargs echo)" = "2"
       meet: ./dbdeployer/install.sh
       down: ./dbdeployer/sandboxes/rsandbox_5_7_22/stop_all
 

--- a/dev.yml
+++ b/dev.yml
@@ -1,8 +1,9 @@
 name: lhm
 up:
   - homebrew:
-      - openssl
-      - shopify/shopify/mysql-client
+      - mysql-client@5.7:
+          or: [mysql@5.7]
+          conflicts: [shopify/shopify/mysql-client, mysql-connector-c, mysql, mysql-client]
       - wget
   - ruby: 2.6.5
   - bundler

--- a/lib/lhm/throttler.rb
+++ b/lib/lhm/throttler.rb
@@ -1,9 +1,12 @@
 require 'lhm/throttler/time'
 require 'lhm/throttler/slave_lag'
+require 'lhm/throttler/threads_running'
 
 module Lhm
   module Throttler
-    CLASSES = { :time_throttler => Throttler::Time, :slave_lag_throttler => Throttler::SlaveLag }
+    CLASSES = { :time_throttler => Throttler::Time,
+                :slave_lag_throttler => Throttler::SlaveLag,
+                :threads_running_throttler => Throttler::ThreadsRunning }
 
     def throttler
       @throttler ||= Throttler::Time.new

--- a/lib/lhm/throttler/threads_running.rb
+++ b/lib/lhm/throttler/threads_running.rb
@@ -1,0 +1,53 @@
+module Lhm
+  module Throttler
+    class ThreadsRunning
+      include Command
+
+      DEFAULT_INITIAL_TIMEOUT = 0.1
+      DEFAULT_HEALTHY_RANGE = (0..50)
+
+      attr_accessor :timeout_seconds, :healthy_range, :connection
+      attr_reader :max_timeout_seconds, :initial_timeout_seconds
+
+      def initialize(options = {})
+        @initial_timeout_seconds = options[:initial_timeout] || DEFAULT_INITIAL_TIMEOUT
+        @max_timeout_seconds = options[:max_timeout] || (@initial_timeout_seconds * 1024)
+        @timeout_seconds = @initial_timeout_seconds
+        @healthy_range = options[:healthy_range] || DEFAULT_HEALTHY_RANGE
+        @connection = options[:connection]
+      end
+
+      def threads_running
+        query = <<~SQL.squish
+              SELECT COUNT(*) as Threads_running
+              FROM (
+                SELECT 1 FROM performance_schema.threads
+                WHERE NAME='thread/sql/one_connection'
+                  AND PROCESSLIST_STATE IS NOT NULL
+                LIMIT #{@healthy_range.max + 1}
+              ) AS LIM
+        SQL
+
+        @connection.select_value(query)
+      end
+
+      def throttle_seconds
+        current_threads_running = threads_running
+
+        if !healthy_range.cover?(current_threads_running) && @timeout_seconds < @max_timeout_seconds
+          Lhm.logger.info("Increasing timeout between strides from #{@timeout_seconds} to #{@timeout_seconds * 2} because threads running is greater than the maximum of #{@healthy_range.max} allowed.")
+          @timeout_seconds = @timeout_seconds * 2
+        elsif healthy_range.cover?(current_threads_running) && @timeout_seconds > @initial_timeout_seconds
+          Lhm.logger.info("Decreasing timeout between strides from #{@timeout_seconds} to #{@timeout_seconds / 2} because threads running is less than the maximum of #{@healthy_range.max} allowed.")
+          @timeout_seconds = @timeout_seconds / 2
+        else
+          @timeout_seconds
+        end
+      end
+
+      def execute
+        sleep throttle_seconds
+      end
+    end
+  end
+end

--- a/spec/unit/throttler/threads_running_spec.rb
+++ b/spec/unit/throttler/threads_running_spec.rb
@@ -1,0 +1,64 @@
+require File.expand_path(File.dirname(__FILE__)) + '/../unit_helper'
+
+require 'lhm/throttler/threads_running'
+
+describe Lhm::Throttler::ThreadsRunning do
+  include UnitHelper
+
+  before :each do
+    @throttler = Lhm::Throttler::ThreadsRunning.new
+  end
+
+  describe '#throttle_seconds' do
+    describe 'with no mysql activity' do
+      before do
+        def @throttler.threads_running
+          0
+        end
+      end
+
+      it 'does not alter the currently set timeout' do
+        timeout = @throttler.timeout_seconds
+        assert_equal(timeout, @throttler.send(:throttle_seconds))
+      end
+    end
+
+    describe 'with an overloaded mysql' do
+      before do
+        def @throttler.threads_running
+          100
+        end
+      end
+
+      it 'doubles the currently set timeout' do
+        timeout = @throttler.timeout_seconds
+        assert_equal(timeout * 2, @throttler.send(:throttle_seconds))
+      end
+
+      it 'does not increase the timeout past the maximum' do
+        @throttler.timeout_seconds = @throttler.max_timeout_seconds
+        assert_equal(@throttler.max_timeout_seconds, @throttler.send(:throttle_seconds))
+      end
+    end
+
+    describe 'with an idle mysql after it has previously been busy' do
+      before do
+        def @throttler.threads_running
+          0
+        end
+      end
+
+      it 'halves the currently set timeout' do
+        @throttler.timeout_seconds *= 2 * 2
+        timeout = @throttler.timeout_seconds
+        assert_equal(timeout / 2, @throttler.send(:throttle_seconds))
+      end
+
+      it 'does not decrease the timeout past the minimum on repeated runs' do
+        @throttler.timeout_seconds = @throttler.initial_timeout_seconds * 2
+        assert_equal(@throttler.initial_timeout_seconds, @throttler.send(:throttle_seconds))
+        assert_equal(@throttler.initial_timeout_seconds, @throttler.send(:throttle_seconds))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sometimes you're in an environment where you can't connect to your replicas to use the `SlaveLag` (sic) throttler, but you want something better than the default `time` based one.

This throttler class will check the current threads running and exponentially back off (to a limit) if they are outside of a predefined range (defaults to `0..50`). This should slow down LHM if it appears to be overloading the database.