### PR TITLE
Run ALTER TABLE inline in tests

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -8,6 +8,8 @@ require 'lhm/throttler'
 require 'lhm/version'
 require 'lhm/cleanup/current'
 require 'lhm/sql_retry'
+require 'lhm/test_support'
+require 'lhm/railtie' if defined?(Rails::Railtie)
 require 'logger'
 
 # Large hadron migrator - online schema change tool

--- a/lib/lhm/railtie.rb
+++ b/lib/lhm/railtie.rb
@@ -1,0 +1,9 @@
+module Lhm
+  class Railtie < Rails::Railtie
+    initializer "lhm.test_setup" do
+      if Rails.env.test? || Rails.env.development?
+        Lhm.execute_inline!
+      end
+    end
+  end
+end

--- a/lib/lhm/test_support.rb
+++ b/lib/lhm/test_support.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Lhm
+  module TestMigrator
+    def initialize(*)
+      super
+      @name = @origin.name
+    end
+
+    def execute
+      @statements.each do |stmt|
+        @connection.execute(tagged(stmt))
+      end
+    end
+  end
+
+  module TestInvoker
+    def run(options = {})
+      normalize_options(options)
+      set_session_lock_wait_timeouts
+      @migrator.run
+    rescue => e
+      Lhm.logger.error("LHM run failed with exception=#{e.class} message=#{e.message}")
+      raise
+    end
+  end
+
+  # Patch LHM to execute ALTER TABLE directly on original tables,
+  # without the online migration dance.
+  # This mode is designed for local/CI environments where we can speed
+  # things up by not invoking "real" LHM logic.
+  def self.execute_inline!
+    Lhm::Migrator.prepend(TestMigrator)
+    Lhm::Invoker.prepend(TestInvoker)
+  end
+end


### PR DESCRIPTION
Core does this thing (https://github.com/Shopify/shopify/pull/50014) and we found that `Shopify/billing` would benefit from it too.

Rather than copy-paste the patch I decided to make it part of `Shopify/lhm`.

This should have zero impact on how migrations are run in production.