### PR TITLE
Corrected is_nullable unless check in renaming column

### DIFF
--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -84,7 +84,8 @@ module Lhm
       col = @origin.columns[old.to_s]
 
       definition = col[:type]
-      definition += ' NOT NULL' unless col[:is_nullable]
+
+      definition += ' NOT NULL' unless col[:is_nullable] == "YES"
       definition += " DEFAULT #{@connection.quote(col[:column_default])}" if col[:column_default]
 
       ddl('alter table `%s` change column `%s` `%s` %s' % [@name, old, nu, definition])


### PR DESCRIPTION
This should resolve issue #97

I don't believe the issue was that the NULL was improperly quoted. The issue was that col[:is_nullable] didn't return a boolean and instead returned "YES"/"NO". Updated the condition to be `unless col[:is_nullable] == "YES"`