### PR TITLE
added comment and collate copying to rename_column

### DIFF
--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -87,6 +87,8 @@ module Lhm
 
       definition += ' NOT NULL' unless col[:is_nullable] == "YES"
       definition += " DEFAULT #{@connection.quote(col[:column_default])}" if col[:column_default]
+      definition += " COMMENT #{@connection.quote(col[:comment])}" if col[:comment]
+      definition += " COLLATE #{@connection.quote(col[:collate])}" if col[:collate]
 
       ddl('alter table `%s` change column `%s` `%s` %s' % [@name, old, nu, definition])
       @renames[old.to_s] = nu.to_s

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -54,11 +54,15 @@ module Lhm
             column_type    = struct_key(defn, 'COLUMN_TYPE')
             is_nullable    = struct_key(defn, 'IS_NULLABLE')
             column_default = struct_key(defn, 'COLUMN_DEFAULT')
+            comment = struct_key(defn, 'COLUMN_COMMENT')
+            collate = struct_key(defn, 'COLLATION_NAME')
 
             table.columns[defn[column_name]] = {
               :type => defn[column_type],
               :is_nullable => defn[is_nullable],
               :column_default => defn[column_default],
+              :comment => defn[comment],
+              :collate => defn[collate],
             }
           end
 


### PR DESCRIPTION
This PR adds logic to the `rename_column` method to keep the `comment` and `collate` values on rename.

> For column definition changes using CHANGE or MODIFY, the definition must include the data type and all attributes that should apply to the new column, other than index attributes such as PRIMARY KEY or UNIQUE. Attributes present in the original definition but not specified for the new definition are not carried forward. 
Source: https://dev.mysql.com/doc/refman/5.7/en/alter-table.html


https://github.com/Shopify/lhm/issues/85 is no longer valid, added a test to validate.



