### PR TITLE
Add retriable errors

### DIFF
--- a/lib/lhm/sql_retry.rb
+++ b/lib/lhm/sql_retry.rb
@@ -43,6 +43,8 @@ module Lhm
             /Lost connection to MySQL server during query/,
             /Max connect timeout reached/,
             /Unknown MySQL server host/,
+            /connection is locked to hostgroup/,
+            /The MySQL server is running with the --read-only option so it cannot execute this statement/,
           ]
         },
         multiplier: 1, # each successive interval grows by this factor


### PR DESCRIPTION
Proxysql will often times mark a hostgroup as readonly temporarily if we miss a heartbeat. Adding this to the list of retriable errors. 