### PR TITLE
Abort migration on duplicate non PRIMARY KEY

### DIFF
--- a/spec/fixtures/composite_primary_key_dest.ddl
+++ b/spec/fixtures/composite_primary_key_dest.ddl
@@ -1,4 +1,4 @@
-CREATE TABLE `composite_primary_key` (
+CREATE TABLE `composite_primary_key_dest` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `shop_id` bigint(20) NOT NULL,
   CONSTRAINT `pk_composite` PRIMARY KEY (`shop_id`,`id`),

--- a/spec/fixtures/custom_primary_key_dest.ddl
+++ b/spec/fixtures/custom_primary_key_dest.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `custom_primary_key_dest` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `pk` varchar(255),
+  PRIMARY KEY (`pk`),
+  UNIQUE KEY `index_custom_primary_key_on_id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/unit/chunker_spec.rb
+++ b/spec/unit/chunker_spec.rb
@@ -41,6 +41,7 @@ describe Lhm::Chunker do
       @connection.expects(:select_value).with(regexp_matches(/where id >= 8 order by id limit 1 offset 4/)).returns(21)
       @connection.expects(:update).with(regexp_matches(/between 1 and 7/)).returns(2)
       @connection.expects(:update).with(regexp_matches(/between 8 and 10/)).returns(2)
+      @connection.expects(:query).twice.with(regexp_matches(/show warnings/)).returns([])
 
       @chunker.run
     end
@@ -87,6 +88,8 @@ describe Lhm::Chunker do
       @connection.expects(:update).with(regexp_matches(/between 3 and 5/)).returns(2)
       @connection.expects(:update).with(regexp_matches(/between 6 and 8/)).returns(2)
       @connection.expects(:update).with(regexp_matches(/between 9 and 10/)).returns(2)
+
+      @connection.expects(:query).twice.with(regexp_matches(/show warnings/)).returns([])
 
       @chunker.run
     end
@@ -136,6 +139,7 @@ describe Lhm::Chunker do
 
       @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 1/)).returns(2)
       @connection.expects(:update).with(regexp_matches(/where \(foo.created_at > '2013-07-10' or foo.baz = 'quux'\) and `foo`/)).returns(1)
+      @connection.expects(:query).with(regexp_matches(/show warnings/)).returns([])
 
       def @migration.conditions
         "where foo.created_at > '2013-07-10' or foo.baz = 'quux'"
@@ -155,6 +159,7 @@ describe Lhm::Chunker do
 
       @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 1/)).returns(2)
       @connection.expects(:update).with(regexp_matches(/inner join bar on foo.id = bar.foo_id and/)).returns(1)
+      @connection.expects(:query).with(regexp_matches(/show warnings/)).returns([])
 
       def @migration.conditions
         'inner join bar on foo.id = bar.foo_id'


### PR DESCRIPTION
Today when migrating a schema that ends up violating a UNIQUE constraint, the records to the new shadow table is dropped silently. This may cause huge silent data loss when, for example, a column is dropped that is part of a UNIQUE index, without modifying or dropping the index. Same problem can occur if we change collation, causing a unique index to ignore case and drop rows silently.

This PR attempts to make these drops halt the migration and alert the operator that this is happening, making it possible to resolve the issue before migrating again. This is done by inspecting any warnings in-case we can see that the number of inserted rows were lower than we expected, signalling ignored rows. These warnings are in most cases fine, since PK duplicates may occur by design, but other constraints should not.