### PR TITLE
handle no display attribute on field

### DIFF
--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -18,7 +18,7 @@ module Lhm
 
     def satisfies_id_column_requirement?
       !!((id = columns['id']) &&
-        id[:type] =~ /(bigint|int)\(\d+\)/)
+        id[:type] =~ /(bigint|int)(\(\d+\))?/)
     end
 
     def destination_name

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -32,6 +32,12 @@ describe Lhm::Table do
       @table.satisfies_id_column_requirement?.must_equal true
     end
 
+    it 'should be satisifed if display attributes are not present (deprecated in mysql 8)' do
+      @table = Lhm::Table.new('table', 'id')
+      set_columns(@table, { 'id' => { :type => 'int' } })
+      @table.satisfies_id_column_requirement?.must_equal true
+    end
+
     it 'should not be satisfied if id is not numeric' do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'varchar(255)' } })


### PR DESCRIPTION
From mysql 8 display attributes on fields are deprecated. This updates
constraint checks to allow for this.

https://dev.mysql.com/worklog/task/?id=13127