### PR TITLE
Release 3.3.6 (added lhm-shopify.rb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 3.3.5 (Jul 5, 2021) 
+# 3.3.6 (Jul 7, 2021)
+
+* Add lhm-shopify.rb to require lhm
+
+# 3.3.5 (Jul 5, 2021)
 
 * Add comment and collate copying to rename_column
 * Publish to rubygems

--- a/lib/lhm-shopify.rb
+++ b/lib/lhm-shopify.rb
@@ -1,0 +1,1 @@
+require "lhm"

--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = '3.3.5'
+  VERSION = '3.3.6'
 end


### PR DESCRIPTION
Added `lhm-shopify.rb` to avoid manually requiring `lhm` on gem usage