### PR TITLE
print deleted trigger and table names to std out

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -114,9 +114,13 @@ module Lhm
       triggers.each do |trigger|
         connection.execute("drop trigger if exists #{trigger}")
       end
+      puts "Dropped triggers #{triggers.join(', ')}"
+
       tables.each do |table|
         connection.execute("drop table if exists #{table}")
       end
+      puts "Dropped tables #{triggers.join(', ')}"
+
       true
     elsif tables.empty? && triggers.empty?
       puts 'Everything is clean. Nothing to do.'

--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -90,6 +90,20 @@ describe Lhm, 'cleanup' do
         Lhm.cleanup(true).must_equal(true)
         Lhm.cleanup.must_equal(true)
       end
+
+      it 'outputs deleted tables and triggers' do
+        output = capture_stdout do
+          Lhm.cleanup(true)
+        end
+        output.must_include(
+          'Dropped triggers lhmt_ins_users, lhmt_upd_users, lhmt_del_users, ' \
+          'lhmt_ins_permissions, lhmt_upd_permissions, lhmt_del_permissions'
+        )
+        output.must_include(
+          'Dropped tables lhmt_ins_users, lhmt_upd_users, lhmt_del_users, ' \
+          'lhmt_ins_permissions, lhmt_upd_permissions, lhmt_del_permissions'
+        )
+      end
     end
 
     describe 'cleanup_current_run' do


### PR DESCRIPTION
It would be useful for the end user to see what has actually happened when they run the clean up task. Right now, the way around this is to run cleanup with `run=false` first to see the "would delete blah blah blah..." output and then afterwards run it with `run=true`. However, the `run=true` option produces no output to confirm what has actually happened.


This PR adds simple output to show the names of the dropped triggers and tables when executing cleanup with run=true.

The test landscape in this gem isn't quite what I expected, so I'm not sure if I've added a test in the right place. My test feels more like a unit test in spirit but it seems like all of the cleanup flows are in `integration/cleanup_spec.rb` so I've added mine there.

