### PR TITLE
Fix minitest deprecation warnings

### DIFF
--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -58,7 +58,7 @@ describe Lhm::AtomicSwitcher do
       switcher.send :define_singleton_method, :atomic_switch do
         'SELECT * FROM nonexistent'
       end
-      -> { switcher.run }.must_raise(ActiveRecord::StatementInvalid)
+      value(-> { switcher.run }).must_raise(ActiveRecord::StatementInvalid)
     end
 
     it "should raise when destination doesn't exist" do
@@ -75,8 +75,8 @@ describe Lhm::AtomicSwitcher do
       switcher.run
 
       slave do
-        data_source_exists?(@origin).must_equal true
-        table_read(@migration.archive_name).columns.keys.must_include 'origin'
+        value(data_source_exists?(@origin)).must_equal true
+        value(table_read(@migration.archive_name).columns.keys).must_include 'origin'
       end
     end
 
@@ -85,8 +85,8 @@ describe Lhm::AtomicSwitcher do
       switcher.run
 
       slave do
-        data_source_exists?(@destination).must_equal false
-        table_read(@origin.name).columns.keys.must_include 'destination'
+        value(data_source_exists?(@destination)).must_equal false
+        value(table_read(@origin.name).columns.keys).must_include 'destination'
       end
     end
   end

--- a/spec/integration/chunk_insert_spec.rb
+++ b/spec/integration/chunk_insert_spec.rb
@@ -22,7 +22,7 @@ describe Lhm::ChunkInsert do
       @instance.insert_and_return_count_of_rows_created
 
       slave do
-        count_all(@destination.name).must_equal(1)
+        value(count_all(@destination.name)).must_equal(1)
       end
     end
   end

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -29,7 +29,7 @@ describe Lhm::Chunker do
       Lhm::Chunker.new(@migration, connection, {throttler: throttler, printer: printer} ).run
 
       slave do
-        count_all(@destination.name).must_equal(1)
+        value(count_all(@destination.name)).must_equal(1)
       end
 
     end
@@ -42,7 +42,7 @@ describe Lhm::Chunker do
       Lhm::Chunker.new(@migration, connection, {throttler: throttler, printer: printer} ).run
 
       slave do
-        count_all(@destination.name).must_equal(2)
+        value(count_all(@destination.name)).must_equal(2)
       end
     end
 
@@ -58,7 +58,7 @@ describe Lhm::Chunker do
       Lhm::Chunker.new(migration, connection, {throttler: throttler, printer: printer} ).run
 
       slave do
-        count_all(destination.name).must_equal(2)
+        value(count_all(destination.name)).must_equal(2)
       end
     end
 
@@ -128,7 +128,7 @@ describe Lhm::Chunker do
       Lhm::Chunker.new(@migration, connection, {throttler: throttler, printer: printer} ).run
 
       slave do
-        count_all(@destination.name).must_equal(0)
+        value(count_all(@destination.name)).must_equal(0)
       end
 
     end
@@ -145,7 +145,7 @@ describe Lhm::Chunker do
       ).run
 
       slave do
-        count_all(@destination.name).must_equal(23)
+        value(count_all(@destination.name)).must_equal(23)
       end
 
       printer.verify
@@ -161,7 +161,7 @@ describe Lhm::Chunker do
       ).run
 
       slave do
-        count_all(@destination.name).must_equal(11)
+        value(count_all(@destination.name)).must_equal(11)
       end
 
     end
@@ -178,7 +178,7 @@ describe Lhm::Chunker do
       ).run
 
       slave do
-        count_all(@destination.name).must_equal(23)
+        value(count_all(@destination.name)).must_equal(23)
       end
 
       printer.verify
@@ -203,7 +203,7 @@ describe Lhm::Chunker do
       assert_equal(Lhm::Throttler::SlaveLag::INITIAL_TIMEOUT * 2 * 2, throttler.timeout_seconds)
 
       slave do
-        count_all(@destination.name).must_equal(15)
+        value(count_all(@destination.name)).must_equal(15)
       end
     end
 
@@ -238,7 +238,7 @@ describe Lhm::Chunker do
       assert_equal(0, throttler.send(:max_current_slave_lag))
 
       slave do
-        count_all(@destination.name).must_equal(15)
+        value(count_all(@destination.name)).must_equal(15)
       end
 
       printer.verify
@@ -260,7 +260,7 @@ describe Lhm::Chunker do
       assert_match "Verification failed, aborting early", exception.message
 
       slave do
-        count_all(@destination.name).must_equal(0)
+        value(count_all(@destination.name)).must_equal(0)
       end
     end
   end

--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -34,9 +34,9 @@ describe Lhm, 'cleanup' do
         output = capture_stdout do
           Lhm.cleanup
         end
-        output.must_include('Would drop LHM backup tables')
-        output.must_match(/lhma_[0-9_]*_users/)
-        output.must_match(/lhma_[0-9_]*_permissions/)
+        value(output).must_include('Would drop LHM backup tables')
+        value(output).must_match(/lhma_[0-9_]*_users/)
+        value(output).must_match(/lhma_[0-9_]*_permissions/)
       end
 
       it 'should show temporary tables within range' do
@@ -51,9 +51,9 @@ describe Lhm, 'cleanup' do
         output = capture_stdout do
           Lhm.cleanup false, { :until => Time.now - 86400 }
         end
-        output.must_include('Would drop LHM backup tables')
-        output.must_match(/lhma_[0-9_]*_users/)
-        output.must_match(/lhma_[0-9_]*_permissions/)
+        value(output).must_include('Would drop LHM backup tables')
+        value(output).must_match(/lhma_[0-9_]*_users/)
+        value(output).must_match(/lhma_[0-9_]*_permissions/)
       end
 
       it 'should exclude temporary tables outside range' do
@@ -68,38 +68,38 @@ describe Lhm, 'cleanup' do
         output = capture_stdout do
           Lhm.cleanup false, { :until => Time.now - 172800 }
         end
-        output.must_include('Would drop LHM backup tables')
-        output.wont_match(/lhma_[0-9_]*_users/)
-        output.wont_match(/lhma_[0-9_]*_permissions/)
+        value(output).must_include('Would drop LHM backup tables')
+        value(output).wont_match(/lhma_[0-9_]*_users/)
+        value(output).wont_match(/lhma_[0-9_]*_permissions/)
       end
 
       it 'should show temporary triggers' do
         output = capture_stdout do
           Lhm.cleanup
         end
-        output.must_include('Would drop LHM triggers')
-        output.must_include('lhmt_ins_users')
-        output.must_include('lhmt_del_users')
-        output.must_include('lhmt_upd_users')
-        output.must_include('lhmt_ins_permissions')
-        output.must_include('lhmt_del_permissions')
-        output.must_include('lhmt_upd_permissions')
+        value(output).must_include('Would drop LHM triggers')
+        value(output).must_include('lhmt_ins_users')
+        value(output).must_include('lhmt_del_users')
+        value(output).must_include('lhmt_upd_users')
+        value(output).must_include('lhmt_ins_permissions')
+        value(output).must_include('lhmt_del_permissions')
+        value(output).must_include('lhmt_upd_permissions')
       end
 
       it 'should delete temporary tables' do
-        Lhm.cleanup(true).must_equal(true)
-        Lhm.cleanup.must_equal(true)
+        value(Lhm.cleanup(true)).must_equal(true)
+        value(Lhm.cleanup).must_equal(true)
       end
 
       it 'outputs deleted tables and triggers' do
         output = capture_stdout do
           Lhm.cleanup(true)
         end
-        output.must_include(
+        value(output).must_include(
           'Dropped triggers lhmt_ins_users, lhmt_upd_users, lhmt_del_users, ' \
           'lhmt_ins_permissions, lhmt_upd_permissions, lhmt_del_permissions'
         )
-        output.must_include(
+        value(output).must_include(
           'Dropped tables lhmt_ins_users, lhmt_upd_users, lhmt_del_users, ' \
           'lhmt_ins_permissions, lhmt_upd_permissions, lhmt_del_permissions'
         )

--- a/spec/integration/entangler_spec.rb
+++ b/spec/integration/entangler_spec.rb
@@ -26,7 +26,7 @@ describe Lhm::Entangler do
       end
 
       slave do
-        count(:destination, 'common', 'inserted').must_equal(1)
+        value(count(:destination, 'common', 'inserted')).must_equal(1)
       end
     end
 
@@ -38,7 +38,7 @@ describe Lhm::Entangler do
       end
 
       slave do
-        count(:destination, 'common', 'inserted').must_equal(0)
+        value(count(:destination, 'common', 'inserted')).must_equal(0)
       end
     end
 
@@ -49,7 +49,7 @@ describe Lhm::Entangler do
       end
 
       slave do
-        count(:destination, 'common', 'updated').must_equal(1)
+        value(count(:destination, 'common', 'updated')).must_equal(1)
       end
     end
 
@@ -59,7 +59,7 @@ describe Lhm::Entangler do
       execute("insert into origin (common) values ('inserted')")
 
       slave do
-        count(:destination, 'common', 'inserted').must_equal(0)
+        value(count(:destination, 'common', 'inserted')).must_equal(0)
       end
     end
   end

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -17,7 +17,7 @@ describe Lhm do
       end
 
       slave do
-        table_read(:users).columns['logins'].must_equal({
+        value(table_read(:users).columns['logins']).must_equal({
           :type           => 'int(12)',
           :is_nullable    => 'YES',
           :column_default => '0',
@@ -35,7 +35,7 @@ describe Lhm do
       end
 
       slave do
-        table_read(:custom_primary_key).columns['logins'].must_equal({
+        value(table_read(:custom_primary_key).columns['logins']).must_equal({
           :type           => 'int(12)',
           :is_nullable    => 'YES',
           :column_default => '0',
@@ -53,7 +53,7 @@ describe Lhm do
       end
 
       slave do
-        table_read(:composite_primary_key).columns['logins'].must_equal({
+        value(table_read(:composite_primary_key).columns['logins']).must_equal({
           :type           => 'int(12)',
           :is_nullable    => 'YES',
           :column_default => '0',
@@ -82,7 +82,7 @@ describe Lhm do
         end
 
         slave do
-          connection.primary_key('users').must_equal(['username', 'id'])
+          value(connection.primary_key('users')).must_equal(['username', 'id'])
         end
       end
 
@@ -104,7 +104,7 @@ describe Lhm do
 
         it 'migrates the existing data' do
           slave do
-            count_all(:permissions).must_equal(11)
+            value(count_all(:permissions)).must_equal(11)
           end
         end
       end
@@ -120,7 +120,7 @@ describe Lhm do
 
         it 'migrates all data' do
           slave do
-            count_all(:permissions).must_equal(13)
+            value(count_all(:permissions)).must_equal(13)
           end
         end
       end
@@ -132,7 +132,7 @@ describe Lhm do
       end
 
       slave do
-        table_read(:users).columns['logins'].must_equal({
+        value(table_read(:users).columns['logins']).must_equal({
           :type => 'int(12)',
           :is_nullable => 'YES',
           :column_default => '0',
@@ -150,7 +150,7 @@ describe Lhm do
       end
 
       slave do
-        count_all(:users).must_equal(23)
+        value(count_all(:users)).must_equal(23)
       end
     end
 
@@ -170,7 +170,7 @@ describe Lhm do
       end
 
       slave do
-        index_on_columns?(:users, [:comment, :created_at]).must_equal(true)
+        value(index_on_columns?(:users, [:comment, :created_at])).must_equal(true)
       end
     end
 
@@ -180,7 +180,7 @@ describe Lhm do
       end
 
       slave do
-        index?(:users, :my_index_name).must_equal(true)
+        value(index?(:users, :my_index_name)).must_equal(true)
       end
     end
 
@@ -190,7 +190,7 @@ describe Lhm do
       end
 
       slave do
-        index_on_columns?(:users, :group).must_equal(true)
+        value(index_on_columns?(:users, :group)).must_equal(true)
       end
     end
 
@@ -200,7 +200,7 @@ describe Lhm do
       end
 
       slave do
-        index_on_columns?(:users, :comment, :unique).must_equal(true)
+        value(index_on_columns?(:users, :comment, :unique)).must_equal(true)
       end
     end
 
@@ -210,7 +210,7 @@ describe Lhm do
       end
 
       slave do
-        index_on_columns?(:users, [:username, :created_at]).must_equal(false)
+        value(index_on_columns?(:users, [:username, :created_at])).must_equal(false)
       end
     end
 
@@ -220,7 +220,7 @@ describe Lhm do
       end
 
       slave do
-        index?(:users, :index_with_a_custom_name).must_equal(false)
+        value(index?(:users, :index_with_a_custom_name)).must_equal(false)
       end
     end
 
@@ -230,7 +230,7 @@ describe Lhm do
       end
 
       slave do
-        index?(:users, :index_with_a_custom_name).must_equal(false)
+        value(index?(:users, :index_with_a_custom_name)).must_equal(false)
       end
     end
 
@@ -240,7 +240,7 @@ describe Lhm do
       end
 
       slave do
-        table_read(:users).columns['flag'].must_equal({
+        value(table_read(:users).columns['flag']).must_equal({
           :type => 'tinyint(1)',
           :is_nullable => 'YES',
           :column_default => nil,
@@ -256,7 +256,7 @@ describe Lhm do
       end
 
       slave do
-        table_read(:users).columns['comment'].must_equal({
+        value(table_read(:users).columns['comment']).must_equal({
           :type => 'varchar(20)',
           :is_nullable => 'NO',
           :column_default => 'none',
@@ -274,7 +274,7 @@ describe Lhm do
       end
 
       slave do
-        table_read(:small_table).columns['id'].must_equal({
+        value(table_read(:small_table).columns['id']).must_equal({
           :type => 'int(5)',
           :is_nullable => 'NO',
           :column_default => nil,
@@ -295,7 +295,7 @@ describe Lhm do
       slave do
         table_data = table_read(:users)
         assert_nil table_data.columns['username']
-        table_read(:users).columns['login'].must_equal({
+        value(table_read(:users).columns['login']).must_equal({
           :type => 'varchar(255)',
           :is_nullable => 'YES',
           :column_default => nil,
@@ -305,7 +305,7 @@ describe Lhm do
 
         result = select_one('SELECT login from users')
         result = result['login'] if result.respond_to?(:has_key?)
-        result.must_equal('a user')
+        value(result).must_equal('a user')
       end
     end
 
@@ -320,7 +320,7 @@ describe Lhm do
       slave do
         table_data = table_read(:users)
         assert_nil table_data.columns['group']
-        table_read(:users).columns['fnord'].must_equal({
+        value(table_read(:users).columns['fnord']).must_equal({
           :type => 'varchar(255)',
           :is_nullable => 'YES',
           :column_default => 'Superfriends',
@@ -330,7 +330,7 @@ describe Lhm do
 
         result = select_one('SELECT `fnord` from users')
         result = result['fnord'] if result.respond_to?(:has_key?)
-        result.must_equal('Superfriends')
+        value(result).must_equal('Superfriends')
       end
     end
 
@@ -347,7 +347,7 @@ describe Lhm do
       slave do
         table_data = table_read(:users)
         assert_nil table_data.columns['username']
-        table_read(:users).columns['user_name'].must_equal({
+        value(table_read(:users).columns['user_name']).must_equal({
              :type => 'varchar(255)',
              :is_nullable => 'YES',
              :column_default => nil,
@@ -357,7 +357,7 @@ describe Lhm do
 
         result = select_one('SELECT `user_name` from users')
         result = result['user_name'] if result.respond_to?(:has_key?)
-        result.must_equal('a user')
+        value(result).must_equal('a user')
       end
     end
 
@@ -375,7 +375,7 @@ describe Lhm do
       slave do
         table_data = table_read(:users)
         assert_nil table_data.columns['reference']
-        table_read(:users).columns['ref'].must_equal({
+        value(table_read(:users).columns['ref']).must_equal({
            :type => 'int(11)',
            :is_nullable => 'YES',
            :column_default => nil,
@@ -385,7 +385,7 @@ describe Lhm do
 
         result = select_one('SELECT `ref` from users')
         result = result['ref'] if result.respond_to?(:has_key?)
-        result.must_equal(10)
+        value(result).must_equal(10)
       end
     end
 
@@ -402,7 +402,7 @@ describe Lhm do
       slave do
         table_data = table_read(:users)
         assert_nil table_data.columns['group']
-        table_read(:users).columns['fnord'].must_equal({
+        value(table_read(:users).columns['fnord']).must_equal({
            :type => 'varchar(255)',
            :is_nullable => 'YES',
            :column_default => nil,
@@ -412,7 +412,7 @@ describe Lhm do
 
         result = select_one('SELECT `fnord` from users')
         result = result['fnord'] if result.respond_to?(:has_key?)
-        result.must_equal(nil)
+        assert_nil(result)
       end
     end
 
@@ -427,7 +427,7 @@ describe Lhm do
       slave do
         table_data = table_read(:users)
         assert_nil table_data.columns['username']
-        table_read(:users).columns['user_name'].must_equal({
+        value(table_read(:users).columns['user_name']).must_equal({
           :type => 'varchar(255)',
           :is_nullable => 'YES',
           :column_default => nil,
@@ -437,7 +437,7 @@ describe Lhm do
 
         result = select_one('SELECT `user_name` from users')
         result = result['user_name'] if result.respond_to?(:has_key?)
-        result.must_equal('a user')
+        value(result).must_equal('a user')
       end
     end
 
@@ -454,7 +454,7 @@ describe Lhm do
       slave do
         table_data = table_read(:users)
         assert_nil table_data.columns['username']
-        table_read(:users).columns['user_name'].must_equal({
+        value(table_read(:users).columns['user_name']).must_equal({
           :type => 'varchar(255)',
           :is_nullable => 'NO',
           :column_default => nil,
@@ -464,7 +464,7 @@ describe Lhm do
 
         result = select_one('SELECT `user_name` from users')
         result = result['user_name'] if result.respond_to?(:has_key?)
-        result.must_equal('a user')
+        value(result).must_equal('a user')
       end
     end
 
@@ -501,7 +501,7 @@ describe Lhm do
       slave do
         table_data = table_read(:users)
         assert_nil table_data.columns['fnord']
-        table_read(:users).columns['group'].must_equal({
+        value(table_read(:users).columns['group']).must_equal({
           :type => 'varchar(255)',
           :is_nullable => 'YES',
           :column_default => 'Superfriends',
@@ -525,11 +525,11 @@ describe Lhm do
       end
 
       slave do
-        table_read(:lines).columns.must_include 'by'
-        table_read(:lines).columns.wont_include 'lines'
-        index_on_columns?(:lines, ['between'], :unique).must_equal true
-        index_on_columns?(:lines, ['by']).must_equal false
-        count_all(:lines).must_equal(2)
+        value(table_read(:lines).columns).must_include 'by'
+        value(table_read(:lines).columns).wont_include 'lines'
+        value(index_on_columns?(:lines, ['between'], :unique)).must_equal true
+        value(index_on_columns?(:lines, ['by'])).must_equal false
+        value(count_all(:lines)).must_equal(2)
       end
     end
 
@@ -554,7 +554,7 @@ describe Lhm do
         insert.join
 
         slave do
-          count_all(:users).must_equal(60)
+          value(count_all(:users)).must_equal(60)
         end
       end
 
@@ -577,7 +577,7 @@ describe Lhm do
         delete.join
 
         slave do
-          count_all(:users).must_equal(40)
+          value(count_all(:users)).must_equal(40)
         end
       end
     end

--- a/spec/integration/lock_wait_timeout_spec.rb
+++ b/spec/integration/lock_wait_timeout_spec.rb
@@ -24,7 +24,7 @@ describe Lhm do
     session_innodb_lock_wait_timeout = connection.select_one("SHOW SESSION VARIABLES LIKE 'innodb_lock_wait_timeout'")['Value'].to_i
     session_lock_wait_timeout = connection.select_one("SHOW SESSION VARIABLES LIKE 'lock_wait_timeout'")['Value'].to_i
 
-    session_lock_wait_timeout.must_equal global_lock_wait_timeout + Lhm::Invoker::LOCK_WAIT_TIMEOUT_DELTA
-    session_innodb_lock_wait_timeout.must_equal global_innodb_lock_wait_timeout + Lhm::Invoker::LOCK_WAIT_TIMEOUT_DELTA
+    value(session_lock_wait_timeout).must_equal global_lock_wait_timeout + Lhm::Invoker::LOCK_WAIT_TIMEOUT_DELTA
+    value(session_innodb_lock_wait_timeout).must_equal global_innodb_lock_wait_timeout + Lhm::Invoker::LOCK_WAIT_TIMEOUT_DELTA
   end
 end

--- a/spec/integration/locked_switcher_spec.rb
+++ b/spec/integration/locked_switcher_spec.rb
@@ -32,8 +32,8 @@ describe Lhm::LockedSwitcher do
       switcher.run
 
       slave do
-        data_source_exists?(@origin).must_equal true
-        table_read(@migration.archive_name).columns.keys.must_include 'origin'
+        value(data_source_exists?(@origin)).must_equal true
+        value(table_read(@migration.archive_name).columns.keys).must_include 'origin'
       end
     end
 
@@ -42,8 +42,8 @@ describe Lhm::LockedSwitcher do
       switcher.run
 
       slave do
-        data_source_exists?(@destination).must_equal false
-        table_read(@origin.name).columns.keys.must_include 'destination'
+        value(data_source_exists?(@destination)).must_equal false
+        value(table_read(@origin.name).columns.keys).must_include 'destination'
       end
     end
   end

--- a/spec/integration/table_spec.rb
+++ b/spec/integration/table_spec.rb
@@ -15,28 +15,24 @@ describe Lhm::Table do
       end
 
       it 'should parse primary key' do
-        @table.pk.must_equal('pk')
+        value(@table.pk).must_equal('pk')
       end
 
       it 'should parse indices' do
-        @table.
-          indices['index_custom_primary_key_on_id'].
-          must_equal(['id'])
+        value(@table.indices['index_custom_primary_key_on_id']).must_equal(['id'])
       end
 
       it 'should parse columns' do
-        @table.
-          columns['id'][:type].
-          must_match(/(bigint|int)\(\d+\)/)
+        value(@table.columns['id'][:type]).must_match(/(bigint|int)\(\d+\)/)
       end
 
       it 'should return true for method that should be renamed' do
-        @table.satisfies_id_column_requirement?.must_equal true
+        value(@table.satisfies_id_column_requirement?).must_equal true
       end
 
       it 'should support bigint tables' do
         @table = table_create(:bigint_table)
-        @table.satisfies_id_column_requirement?.must_equal true
+        value(@table.satisfies_id_column_requirement?).must_equal true
       end
     end
 
@@ -47,7 +43,7 @@ describe Lhm::Table do
 
       it 'should return false for a non-int id column' do
         @table = table_create(:wo_id_int_column)
-        @table.satisfies_id_column_requirement?.must_equal false
+        value(@table.satisfies_id_column_requirement?).must_equal false
       end
     end
   end
@@ -60,15 +56,15 @@ describe Lhm::Table do
       end
 
       it 'should parse table name in show create table' do
-        @table.name.must_equal('users')
+        value(@table.name).must_equal('users')
       end
 
       it 'should parse primary key' do
-        @table.pk.must_equal('id')
+        value(@table.pk).must_equal('id')
       end
 
       it 'should parse column type in show create table' do
-        @table.columns['username'][:type].must_equal('varchar(255)')
+        value(@table.columns['username'][:type]).must_equal('varchar(255)')
       end
 
       it 'should parse column metadata' do
@@ -76,15 +72,11 @@ describe Lhm::Table do
       end
 
       it 'should parse indices' do
-        @table.
-          indices['index_users_on_username_and_created_at'].
-          must_equal(['username', 'created_at'])
+        value(@table.indices['index_users_on_username_and_created_at']).must_equal(['username', 'created_at'])
       end
 
       it 'should parse index' do
-        @table.
-          indices['index_users_on_reference'].
-          must_equal(['reference'])
+        value(@table.indices['index_users_on_reference']).must_equal(['reference'])
       end
     end
   end

--- a/spec/unit/atomic_switcher_spec.rb
+++ b/spec/unit/atomic_switcher_spec.rb
@@ -20,12 +20,10 @@ describe Lhm::AtomicSwitcher do
 
   describe 'atomic switch' do
     it 'should perform a single atomic rename' do
-      @switcher.
-        atomic_switch.
-        must_equal(
-          "rename table `origin` to `#{ @migration.archive_name }`, " \
-          '`destination` to `origin`'
-        )
+      value(@switcher.atomic_switch).must_equal(
+        "rename table `origin` to `#{ @migration.archive_name }`, " \
+        '`destination` to `origin`'
+      )
     end
   end
 end

--- a/spec/unit/entangler_spec.rb
+++ b/spec/unit/entangler_spec.rb
@@ -34,7 +34,7 @@ describe Lhm::Entangler do
         values (`NEW`.`info`, `NEW`.`tags`)
       }
 
-      @entangler.entangle.must_include strip(ddl)
+      value(@entangler.entangle).must_include strip(ddl)
     end
 
     it 'should create an update trigger to the destination table' do
@@ -45,7 +45,7 @@ describe Lhm::Entangler do
         values (`NEW`.`info`, `NEW`.`tags`)
       }
 
-      @entangler.entangle.must_include strip(ddl)
+      value(@entangler.entangle).must_include strip(ddl)
     end
 
     it 'should create a delete trigger to the destination table' do
@@ -56,7 +56,7 @@ describe Lhm::Entangler do
         where `destination`.`id` = OLD.`id`
       }
 
-      @entangler.entangle.must_include strip(ddl)
+      value(@entangler.entangle).must_include strip(ddl)
     end
 
     it 'should retry trigger creation when it hits a lock wait timeout' do
@@ -101,24 +101,24 @@ describe Lhm::Entangler do
       end
 
       it 'should use truncated names' do
-        @entangler.trigger(:ins).length.must_be :<=, 64
-        @entangler.trigger(:upd).length.must_be :<=, 64
-        @entangler.trigger(:del).length.must_be :<=, 64
+        value(@entangler.trigger(:ins).length).must_be :<=, 64
+        value(@entangler.trigger(:upd).length).must_be :<=, 64
+        value(@entangler.trigger(:del).length).must_be :<=, 64
       end
     end
   end
 
   describe 'removal' do
     it 'should remove insert trigger' do
-      @entangler.untangle.must_include('drop trigger if exists `lhmt_ins_origin`')
+      value(@entangler.untangle).must_include('drop trigger if exists `lhmt_ins_origin`')
     end
 
     it 'should remove update trigger' do
-      @entangler.untangle.must_include('drop trigger if exists `lhmt_upd_origin`')
+      value(@entangler.untangle).must_include('drop trigger if exists `lhmt_upd_origin`')
     end
 
     it 'should remove delete trigger' do
-      @entangler.untangle.must_include('drop trigger if exists `lhmt_del_origin`')
+      value(@entangler.untangle).must_include('drop trigger if exists `lhmt_del_origin`')
     end
   end
 end

--- a/spec/unit/intersection_spec.rb
+++ b/spec/unit/intersection_spec.rb
@@ -18,7 +18,7 @@ describe Lhm::Intersection do
     destination.columns['retained'] = varchar
 
     intersection = Lhm::Intersection.new(origin, destination)
-    intersection.destination.include?('dropped').must_equal(false)
+    value(intersection.destination.include?('dropped')).must_equal(false)
   end
 
   it 'should have unchanged columns' do
@@ -30,7 +30,7 @@ describe Lhm::Intersection do
     destination.columns['retained'] = varchar
 
     intersection = Lhm::Intersection.new(origin, destination)
-    intersection.destination.must_equal(['retained'])
+    value(intersection.destination).must_equal(['retained'])
   end
 
   it 'should have renamed columns' do
@@ -41,8 +41,8 @@ describe Lhm::Intersection do
     destination.columns['new_name'] = varchar
 
     intersection = Lhm::Intersection.new(origin, destination, { 'old_name' => 'new_name' })
-    intersection.origin.must_equal(['old_name'])
-    intersection.destination.must_equal(['new_name'])
+    value(intersection.origin).must_equal(['old_name'])
+    value(intersection.destination).must_equal(['new_name'])
   end
 
   def varchar

--- a/spec/unit/lhm_spec.rb
+++ b/spec/unit/lhm_spec.rb
@@ -11,9 +11,9 @@ describe Lhm do
   describe 'logger' do
 
     it 'should use the default parameters if no logger explicitly set' do
-      Lhm.logger.must_be_kind_of Logger
-      Lhm.logger.level.must_equal Logger::INFO
-      Lhm.logger.instance_eval { @logdev }.dev.must_equal STDOUT
+      value(Lhm.logger).must_be_kind_of Logger
+      value(Lhm.logger.level).must_equal Logger::INFO
+      value(Lhm.logger.instance_eval { @logdev }.dev).must_equal STDOUT
     end
 
     it 'should use s new logger if set' do
@@ -21,9 +21,9 @@ describe Lhm do
       l.level = Logger::ERROR
       Lhm.logger = l
 
-      Lhm.logger.level.must_equal Logger::ERROR
-      Lhm.logger.instance_eval { @logdev }.dev.must_be_kind_of File
-      Lhm.logger.instance_eval { @logdev }.dev.path.must_equal 'omg.ponies'
+      value(Lhm.logger.level).must_equal Logger::ERROR
+      value(Lhm.logger.instance_eval { @logdev }.dev).must_be_kind_of File
+      value(Lhm.logger.instance_eval { @logdev }.dev.path).must_equal 'omg.ponies'
     end
   end
 end

--- a/spec/unit/locked_switcher_spec.rb
+++ b/spec/unit/locked_switcher_spec.rb
@@ -20,32 +20,27 @@ describe Lhm::LockedSwitcher do
 
   describe 'uncommitted' do
     it 'should disable autocommit first' do
-      @switcher.
-        statements[0..1].
-        must_equal([
-          'set @lhm_auto_commit = @@session.autocommit',
-          'set session autocommit = 0'
-        ])
+      value(@switcher.statements[0..1]).must_equal([
+        'set @lhm_auto_commit = @@session.autocommit',
+        'set session autocommit = 0'
+      ])
     end
 
     it 'should reapply original autocommit settings at the end' do
-      @switcher.
-        statements[-1].
-        must_equal('set session autocommit = @lhm_auto_commit')
+      value(@switcher.statements[-1])
+        .must_equal('set session autocommit = @lhm_auto_commit')
     end
   end
 
   describe 'switch' do
     it 'should lock origin and destination table, switch, commit and unlock' do
-      @switcher.
-        switch.
-        must_equal([
-          'lock table `origin` write, `destination` write',
-          "alter table `origin` rename `#{ @migration.archive_name }`",
-          'alter table `destination` rename `origin`',
-          'commit',
-          'unlock tables'
-        ])
+      value(@switcher.switch).must_equal([
+        'lock table `origin` write, `destination` write',
+        "alter table `origin` rename `#{ @migration.archive_name }`",
+        'alter table `destination` rename `origin`',
+        'commit',
+        'unlock tables'
+      ])
     end
   end
 end

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -18,7 +18,7 @@ describe Lhm::Migrator do
     it 'should add an index' do
       @creator.add_index(:a)
 
-      @creator.statements.must_equal([
+      value(@creator.statements).must_equal([
         'create index `index_alt_on_a` on `lhmn_alt` (`a`)'
       ])
     end
@@ -26,7 +26,7 @@ describe Lhm::Migrator do
     it 'should add a composite index' do
       @creator.add_index([:a, :b])
 
-      @creator.statements.must_equal([
+      value(@creator.statements).must_equal([
         'create index `index_alt_on_a_and_b` on `lhmn_alt` (`a`, `b`)'
       ])
     end
@@ -34,7 +34,7 @@ describe Lhm::Migrator do
     it 'should add an index with prefix length' do
       @creator.add_index(['a(10)', 'b'])
 
-      @creator.statements.must_equal([
+      value(@creator.statements).must_equal([
         'create index `index_alt_on_a_and_b` on `lhmn_alt` (`a`(10), `b`)'
       ])
     end
@@ -42,7 +42,7 @@ describe Lhm::Migrator do
     it 'should add an index with a custom name' do
       @creator.add_index([:a, :b], :custom_index_name)
 
-      @creator.statements.must_equal([
+      value(@creator.statements).must_equal([
         'create index `custom_index_name` on `lhmn_alt` (`a`, `b`)'
       ])
     end
@@ -56,7 +56,7 @@ describe Lhm::Migrator do
     it 'should add a unique index' do
       @creator.add_unique_index(['a(5)', :b])
 
-      @creator.statements.must_equal([
+      value(@creator.statements).must_equal([
         'create unique index `index_alt_on_a_and_b` on `lhmn_alt` (`a`(5), `b`)'
       ])
     end
@@ -64,7 +64,7 @@ describe Lhm::Migrator do
     it 'should add a unique index with a custom name' do
       @creator.add_unique_index([:a, :b], :custom_index_name)
 
-      @creator.statements.must_equal([
+      value(@creator.statements).must_equal([
         'create unique index `custom_index_name` on `lhmn_alt` (`a`, `b`)'
       ])
     end
@@ -78,7 +78,7 @@ describe Lhm::Migrator do
     it 'should remove an index' do
       @creator.remove_index(['b', 'a'])
 
-      @creator.statements.must_equal([
+      value(@creator.statements).must_equal([
         'drop index `index_alt_on_b_and_a` on `lhmn_alt`'
       ])
     end
@@ -86,7 +86,7 @@ describe Lhm::Migrator do
     it 'should remove an index with a custom name' do
       @creator.remove_index([:a, :b], :custom_index_name)
 
-      @creator.statements.must_equal([
+      value(@creator.statements).must_equal([
         'drop index `custom_index_name` on `lhmn_alt`'
       ])
     end
@@ -96,7 +96,7 @@ describe Lhm::Migrator do
     it 'should add a column' do
       @creator.add_column('logins', 'INT(12)')
 
-      @creator.statements.must_equal([
+      value(@creator.statements).must_equal([
         'alter table `lhmn_alt` add column `logins` INT(12)'
       ])
     end
@@ -104,7 +104,7 @@ describe Lhm::Migrator do
     it 'should remove a column' do
       @creator.remove_column('logins')
 
-      @creator.statements.must_equal([
+      value(@creator.statements).must_equal([
         'alter table `lhmn_alt` drop `logins`'
       ])
     end
@@ -112,7 +112,7 @@ describe Lhm::Migrator do
     it 'should change a column' do
       @creator.change_column('logins', 'INT(11)')
 
-      @creator.statements.must_equal([
+      value(@creator.statements).must_equal([
         'alter table `lhmn_alt` modify column `logins` INT(11)'
       ])
     end
@@ -122,7 +122,7 @@ describe Lhm::Migrator do
     it 'should accept a ddl statement' do
       @creator.ddl('alter table `%s` add column `f` tinyint(1)' % @creator.name)
 
-      @creator.statements.must_equal([
+      value(@creator.statements).must_equal([
         'alter table `lhmn_alt` add column `f` tinyint(1)'
       ])
     end
@@ -132,15 +132,13 @@ describe Lhm::Migrator do
     it 'should add two columns' do
       @creator.add_column('first', 'VARCHAR(64)')
       @creator.add_column('last', 'VARCHAR(64)')
-      @creator.statements.length.must_equal(2)
+      value(@creator.statements.length).must_equal(2)
 
-      @creator.
-        statements[0].
-        must_equal('alter table `lhmn_alt` add column `first` VARCHAR(64)')
+      value(@creator.statements[0])
+        .must_equal('alter table `lhmn_alt` add column `first` VARCHAR(64)')
 
-      @creator.
-        statements[1].
-        must_equal('alter table `lhmn_alt` add column `last` VARCHAR(64)')
+      value(@creator.statements[1])
+        .must_equal('alter table `lhmn_alt` add column `last` VARCHAR(64)')
     end
   end
 end

--- a/spec/unit/sql_helper_spec.rb
+++ b/spec/unit/sql_helper_spec.rb
@@ -7,26 +7,22 @@ require 'lhm/sql_helper'
 
 describe Lhm::SqlHelper do
   it 'should name index with a single column' do
-    Lhm::SqlHelper.
-      idx_name(:users, :name).
-      must_equal('index_users_on_name')
+    value(Lhm::SqlHelper.idx_name(:users, :name))
+      .must_equal('index_users_on_name')
   end
 
   it 'should name index with multiple columns' do
-    Lhm::SqlHelper.
-      idx_name(:users, [:name, :firstname]).
-      must_equal('index_users_on_name_and_firstname')
+    value(Lhm::SqlHelper.idx_name(:users, [:name, :firstname]))
+      .must_equal('index_users_on_name_and_firstname')
   end
 
   it 'should name index with prefixed column' do
-    Lhm::SqlHelper.
-      idx_name(:tracks, ['title(10)', 'album']).
-      must_equal('index_tracks_on_title_and_album')
+    value(Lhm::SqlHelper.idx_name(:tracks, ['title(10)', 'album']))
+      .must_equal('index_tracks_on_title_and_album')
   end
 
   it 'should quote column names in index specification' do
-    Lhm::SqlHelper.
-      idx_spec(['title(10)', 'album']).
-      must_equal('`title`(10), `album`')
+    value(Lhm::SqlHelper.idx_spec(['title(10)', 'album']))
+      .must_equal('`title`(10), `album`')
   end
 end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -11,7 +11,7 @@ describe Lhm::Table do
   describe 'names' do
     it 'should name destination' do
       @table = Lhm::Table.new('users')
-      @table.destination_name.must_equal 'lhmn_users'
+      value(@table.destination_name).must_equal 'lhmn_users'
     end
   end
 
@@ -23,25 +23,25 @@ describe Lhm::Table do
     it 'should be satisfied with a single column primary key called id' do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'int(1)' } })
-      @table.satisfies_id_column_requirement?.must_equal true
+      value(@table.satisfies_id_column_requirement?).must_equal true
     end
 
     it 'should be satisfied with a primary key not called id, as long as there is still an id' do
       @table = Lhm::Table.new('table', 'uuid')
       set_columns(@table, { 'id' => { :type => 'int(1)' } })
-      @table.satisfies_id_column_requirement?.must_equal true
+      value(@table.satisfies_id_column_requirement?).must_equal true
     end
 
     it 'should be satisifed if display attributes are not present (deprecated in mysql 8)' do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'int' } })
-      @table.satisfies_id_column_requirement?.must_equal true
+      value(@table.satisfies_id_column_requirement?).must_equal true
     end
 
     it 'should not be satisfied if id is not numeric' do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'varchar(255)' } })
-      @table.satisfies_id_column_requirement?.must_equal false
+      value(@table.satisfies_id_column_requirement?).must_equal false
     end
   end
 end

--- a/spec/unit/throttler_spec.rb
+++ b/spec/unit/throttler_spec.rb
@@ -23,11 +23,11 @@ describe Lhm::Throttler do
       end
 
       it 'instantiates the time throttle' do
-        @mock.throttler.class.must_equal Lhm::Throttler::Time
+        value(@mock.throttler.class).must_equal Lhm::Throttler::Time
       end
 
       it 'returns 2 seconds as time' do
-        @mock.throttler.timeout_seconds.must_equal 2
+        value(@mock.throttler.timeout_seconds).must_equal 2
       end
     end
 
@@ -37,11 +37,11 @@ describe Lhm::Throttler do
       end
 
       it 'instantiates the slave_lag throttle' do
-        @mock.throttler.class.must_equal Lhm::Throttler::SlaveLag
+        value(@mock.throttler.class).must_equal Lhm::Throttler::SlaveLag
       end
 
       it 'returns 20 seconds as allowed_lag' do
-        @mock.throttler.allowed_lag.must_equal 20
+        value(@mock.throttler.allowed_lag).must_equal 20
       end
     end
 
@@ -58,11 +58,11 @@ describe Lhm::Throttler do
       end
 
       it 'returns the instace given' do
-        @mock.throttler.must_equal @instance
+        value(@mock.throttler).must_equal @instance
       end
 
       it 'returns 0 seconds as time' do
-        @mock.throttler.timeout_seconds.must_equal 0
+        value(@mock.throttler.timeout_seconds).must_equal 0
       end
     end
 
@@ -78,11 +78,11 @@ describe Lhm::Throttler do
       end
 
       it 'returns the instace given' do
-        @mock.throttler.must_equal @instance
+        value(@mock.throttler).must_equal @instance
       end
 
       it 'returns 0 seconds as time' do
-        @mock.throttler.timeout_seconds.must_equal 0
+        value(@mock.throttler.timeout_seconds).must_equal 0
       end
     end
 
@@ -94,7 +94,7 @@ describe Lhm::Throttler do
       end
 
       it 'has the same class as given' do
-        @mock.throttler.class.must_equal @klass
+        value(@mock.throttler.class).must_equal @klass
       end
     end
 
@@ -106,7 +106,7 @@ describe Lhm::Throttler do
       end
 
       it 'has the same class as given' do
-        @mock.throttler.class.must_equal @klass
+        value(@mock.throttler.class).must_equal @klass
       end
     end
   end
@@ -114,11 +114,11 @@ describe Lhm::Throttler do
   describe '#throttler' do
 
     it 'returns the default Time based' do
-      @mock.throttler.class.must_equal Lhm::Throttler::Time
+      value(@mock.throttler.class).must_equal Lhm::Throttler::Time
     end
 
     it 'should default to 100 milliseconds' do
-      @mock.throttler.timeout_seconds.must_equal 0.1
+      value(@mock.throttler.timeout_seconds).must_equal 0.1
     end
   end
 end


### PR DESCRIPTION
Minitest has deprecated all the expectation methods (must_equal, must_be, ...) in the global `Object` namespace. Instead you're supposed to use the [_(value = nil, &block)](http://docs.seattlerb.org/minitest/Minitest/Spec/DSL/InstanceMethods.html) method which returns a value monad that has all of expectation methods available on it. The method is also aliased to `value` and `expect`, so these examples are basically identical:

```
     _(1 + 1).must_equal(2)
 value(1 + 1).must_equal(2)
expect(1 + 1).must_equal(2)
```

After talking to @tiwilliam, we decided to go with `value`.