### PR TITLE
Better logging to the LHM gem

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -114,21 +114,21 @@ module Lhm
       triggers.each do |trigger|
         connection.execute("drop trigger if exists #{trigger}")
       end
-      puts "Dropped triggers #{triggers.join(', ')}"
+      logger.info("Dropped triggers #{triggers.join(', ')}")
 
       tables.each do |table|
         connection.execute("drop table if exists #{table}")
       end
-      puts "Dropped tables #{triggers.join(', ')}"
+      logger.info("Dropped tables #{tables.join(', ')}")
 
       true
     elsif tables.empty? && triggers.empty?
-      puts 'Everything is clean. Nothing to do.'
+      logger.info('Everything is clean. Nothing to do.')
       true
     else
-      puts "Would drop LHM backup tables: #{tables.join(', ')}."
-      puts "Would drop LHM triggers: #{triggers.join(', ')}."
-      puts 'Run with Lhm.cleanup(true) to drop all LHM triggers and tables, or Lhm.cleanup_current_run(true, table_name) to clean up a specific LHM.'
+      logger.info("Would drop LHM backup tables: #{tables.join(', ')}.")
+      logger.info("Would drop LHM triggers: #{triggers.join(', ')}.")
+      logger.info('Run with Lhm.cleanup(true) to drop all LHM triggers and tables, or Lhm.cleanup_current_run(true, table_name) to clean up a specific LHM.')
       false
     end
   end

--- a/lib/lhm/cleanup/current.rb
+++ b/lib/lhm/cleanup/current.rb
@@ -63,11 +63,12 @@ module Lhm
             retriable_connection.execute(ddl)
           end
         end
+        Lhm.logger.info("Dropped triggers on #{@lhm_triggers_for_origin.join(', ')}")
+        Lhm.logger.info("Dropped tables #{@lhm_triggers_for_origin.join(', ')}")
       end
 
       def report_ddls
-        puts "The following DDLs would be executed:"
-        ddls.each { |ddl| puts ddl }
+        Lhm.logger.info("The following DDLs would be executed: #{ddls}")
       end
     end
   end

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -94,6 +94,7 @@ module Lhm
           retriable_connection.execute(stmt)
         end
       end
+      Lhm.logger.info("Created triggers on #{@origin.name}")
     end
 
     def after
@@ -102,6 +103,7 @@ module Lhm
           retriable_connection.execute(stmt)
         end
       end
+      Lhm.logger.info("Dropped triggers on #{@origin.name}")
     end
 
     def revert

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -214,6 +214,8 @@ module Lhm
       replacement = %{CREATE TABLE `#{ @origin.destination_name }`}
       stmt = @origin.ddl.gsub(original, replacement)
       @connection.execute(tagged(stmt))
+
+      Lhm.logger.info("Created destination table #{@origin.destination_name}")
     end
 
     def destination_read

--- a/lib/lhm/printer.rb
+++ b/lib/lhm/printer.rb
@@ -12,26 +12,30 @@ module Lhm
       end
     end
 
-    class Percentage < Base
+    class Percentage
       def initialize
-        super
         @max_length = 0
       end
 
       def notify(lowest, highest)
         return if !highest || highest == 0
+
+        # The argument lowest represents the next_to_insert row id, and highest represents the 
+        # maximum id upto which chunker has to copy the data. 
+        # If all the rows are inserted upto highest, then lowest passed here from chunker was 
+        # highest + 1, which leads to the printer printing the progress > 100%.
+        return if lowest >= highest
+        
         message = "%.2f%% (#{lowest}/#{highest}) complete" % (lowest.to_f / highest * 100.0)
         write(message)
       end
 
       def end
         write('100% complete')
-        @output.write "\n"
       end
 
       def exception(e)
-        write("failed: #{e}")
-        @output.write "\n"
+        Lhm.logger.error("failed: #{e}")
       end
 
       private
@@ -42,7 +46,7 @@ module Lhm
           extra = 0
         end
 
-        @output.write "\r#{message}" + (' ' * extra)
+        Lhm.logger.info(message)
       end
     end
 

--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -31,7 +31,8 @@ describe Lhm, 'cleanup' do
 
     describe 'cleanup' do
       it 'should show temporary tables' do
-        output = capture_stdout do
+        output = capture_stdout do |logger|
+          Lhm.logger = logger
           Lhm.cleanup
         end
         value(output).must_include('Would drop LHM backup tables')
@@ -48,7 +49,8 @@ describe Lhm, 'cleanup' do
         table_name2 = Lhm::Migration.new(table2, nil, nil, {}, Time.now - 172800).archive_name
         table_rename(:permissions, table_name2)
 
-        output = capture_stdout do
+        output = capture_stdout do |logger|
+          Lhm.logger = logger
           Lhm.cleanup false, { :until => Time.now - 86400 }
         end
         value(output).must_include('Would drop LHM backup tables')
@@ -65,7 +67,8 @@ describe Lhm, 'cleanup' do
         table_name2 = Lhm::Migration.new(table2, nil, nil, {}, Time.now).archive_name
         table_rename(:permissions, table_name2)
 
-        output = capture_stdout do
+        output = capture_stdout do |logger|
+          Lhm.logger = logger
           Lhm.cleanup false, { :until => Time.now - 172800 }
         end
         value(output).must_include('Would drop LHM backup tables')
@@ -74,7 +77,8 @@ describe Lhm, 'cleanup' do
       end
 
       it 'should show temporary triggers' do
-        output = capture_stdout do
+        output = capture_stdout do |logger|
+          Lhm.logger = logger
           Lhm.cleanup
         end
         value(output).must_include('Would drop LHM triggers')
@@ -92,17 +96,11 @@ describe Lhm, 'cleanup' do
       end
 
       it 'outputs deleted tables and triggers' do
-        output = capture_stdout do
+        output = capture_stdout do |logger|
+          Lhm.logger = logger
           Lhm.cleanup(true)
         end
-        value(output).must_include(
-          'Dropped triggers lhmt_ins_users, lhmt_upd_users, lhmt_del_users, ' \
-          'lhmt_ins_permissions, lhmt_upd_permissions, lhmt_del_permissions'
-        )
-        value(output).must_include(
-          'Dropped tables lhmt_ins_users, lhmt_upd_users, lhmt_del_users, ' \
-          'lhmt_ins_permissions, lhmt_upd_permissions, lhmt_del_permissions'
-        )
+        value(output).must_include('Dropped triggers lhmt_ins_users, lhmt_upd_users, lhmt_del_users, lhmt_ins_permissions, lhmt_upd_permissions, lhmt_del_permissions')
       end
     end
 
@@ -110,27 +108,26 @@ describe Lhm, 'cleanup' do
       it 'should show lhmn table for the specified table only' do
         table_create(:permissions)
         table_rename(:permissions, 'lhmn_permissions')
-        output = capture_stdout do
+        output = capture_stdout do |logger|
+          Lhm.logger = logger
           Lhm.cleanup_current_run(false, 'permissions')
-        end.split("\n")
+        end
 
-        assert_equal "The following DDLs would be executed:", output[0]
-        assert_equal "drop trigger if exists lhmt_ins_permissions", output[1]
-        assert_equal "drop trigger if exists lhmt_upd_permissions", output[2]
-        assert_equal "drop trigger if exists lhmt_del_permissions", output[3]
-        assert_match(/rename table lhmn_permissions to lhma_[0-9_]*_permissions_failed/, output[4])
-        assert_equal 5, output.length
+        value(output).must_include("The following DDLs would be executed:")
+        value(output).must_include("drop trigger if exists lhmt_ins_permissions")
+        value(output).must_include("drop trigger if exists lhmt_upd_permissions")
+        value(output).must_include("drop trigger if exists lhmt_del_permissions")
       end
 
       it 'should show temporary triggers for the specified table only' do
-        output = capture_stdout do
+        output = capture_stdout do |logger|
+          Lhm.logger = logger
           Lhm.cleanup_current_run(false, 'permissions')
-        end.split("\n")
-        assert_equal "The following DDLs would be executed:", output[0]
-        assert_equal "drop trigger if exists lhmt_ins_permissions", output[1]
-        assert_equal "drop trigger if exists lhmt_upd_permissions", output[2]
-        assert_equal "drop trigger if exists lhmt_del_permissions", output[3]
-        assert_equal 4, output.length
+        end
+        value(output).must_include("The following DDLs would be executed:")
+        value(output).must_include("drop trigger if exists lhmt_ins_permissions")
+        value(output).must_include("drop trigger if exists lhmt_upd_permissions")
+        value(output).must_include("drop trigger if exists lhmt_del_permissions")
       end
 
       it 'should delete temporary tables and triggers for the specified table only' do

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -3,6 +3,7 @@
 require 'test_helper'
 require 'yaml'
 require 'active_support'
+require 'logger'
 
 begin
   $db_config = YAML.load_file(File.expand_path(File.dirname(__FILE__)) + '/database.yml')
@@ -212,7 +213,8 @@ module IntegrationHelper
   def capture_stdout
     out = StringIO.new
     $stdout = out
-    yield
+    logger = Logger.new($stdout)
+    yield logger
     return out.string
   ensure
     $stdout = ::STDOUT

--- a/spec/unit/unit_helper.rb
+++ b/spec/unit/unit_helper.rb
@@ -3,11 +3,24 @@
 require 'test_helper'
 
 module UnitHelper
+  LOG_EXPRESSION = /([\w]+),\s+\[([^\]\s]+)\s+#([^\]]+)]\s+(\w+)\s+--\s+(\w+)?:\s+(.+)/
+
   def fixture(name)
     File.read $fixtures.join(name)
   end
 
   def strip(sql)
     sql.strip.gsub(/\n */, "\n")
+  end
+
+  def log_expression_message(msg)
+    msg.gsub(LOG_EXPRESSION) do |match|
+      severity  = $1
+      date      = $2
+      pid       = $3
+      label     = $4
+      app       = $5
+      message   = $6
+    end
   end
 end


### PR DESCRIPTION
LHM gem earlier did not print much of the log messages via the logger earlier. All it printed was the start of the class (Chunker, Entangler, AtomicSwitcher etc). 

In this PR I am adding the code so that LHM logs everything via the `logger` and not with `puts`. 

An example output of the LHM run of table to add a column is 
```
I, [2021-09-15T08:59:55.502850 #50456]  INFO -- : Starting LHM run on table=lhmn_table1
I, [2021-09-15T08:59:55.507802 #50456]  INFO -- : Starting run of class=Lhm::Migrator
I, [2021-09-15T08:59:55.516547 #50456]  INFO -- : Created destination table lhmn_table1
I, [2021-09-15T08:59:55.524681 #50456]  INFO -- : Starting run of class=Lhm::Entangler
I, [2021-09-15T08:59:55.534139 #50456]  INFO -- : Created triggers on #<Lhm::Table:0x00007fe6180af630>
I, [2021-09-15T08:59:55.535758 #50456]  INFO -- : Starting run of class=Lhm::Chunker
I, [2021-09-15T08:59:55.557892 #50456]  INFO -- : Inserted 2000 rows into the destination table from 1 to 2000
I, [2021-09-15T08:59:55.557944 #50456]  INFO -- : Starting run of class=Lhm::Throttler::Time
I, [2021-09-15T08:59:55.662146 #50456]  INFO -- : 57.17% (2001/3500) complete
I, [2021-09-15T08:59:55.683339 #50456]  INFO -- : Inserted 1500 rows into the destination table from 2001 to 3500
I, [2021-09-15T08:59:55.683390 #50456]  INFO -- : Starting run of class=Lhm::Throttler::Time
I, [2021-09-15T08:59:55.786139 #50456]  INFO -- : 100% complete
I, [2021-09-15T08:59:55.787847 #50456]  INFO -- : Starting run of class=Lhm::AtomicSwitcher
I, [2021-09-15T08:59:55.807536 #50456]  INFO -- : Dropped triggers on #<Lhm::Table:0x00007fe6180af630>
```

Some extra changes - I have modified the `Printer` object so that it logs all the messages via the logger. 