### PR TITLE
Added a `Connection` class to isolate SQLRetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,5 @@ gemfiles/vendor
 omg.ponies
 *~
 coverage
-bin/dbdeployer
-/dbdeployer/sandboxes
-/dbdeployer/binaries
+.idea/
 Gemfile.lock

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -8,6 +8,7 @@ require 'lhm/throttler'
 require 'lhm/version'
 require 'lhm/cleanup/current'
 require 'lhm/sql_retry'
+require 'lhm/connection'
 require 'lhm/test_support'
 require 'lhm/railtie' if defined?(Rails::Railtie)
 require 'logger'
@@ -82,7 +83,7 @@ module Lhm
   end
 
   def setup(connection)
-    @@connection = connection
+    @@connection = Lhm::Connection.new(connection: connection)
   end
 
   def connection

--- a/lib/lhm/chunk_insert.rb
+++ b/lib/lhm/chunk_insert.rb
@@ -2,15 +2,16 @@ require 'lhm/sql_retry'
 
 module Lhm
   class ChunkInsert
-    def initialize(migration, connection, lowest, highest)
+    def initialize(migration, connection, lowest, highest, options = {})
       @migration = migration
       @connection = connection
       @lowest = lowest
       @highest = highest
+      @retry_options = options[:retriable] || {}
     end
 
     def insert_and_return_count_of_rows_created
-      @connection.update sql
+      @connection.update(sql, @retry_options)
     end
 
     def sql

--- a/lib/lhm/chunk_insert.rb
+++ b/lib/lhm/chunk_insert.rb
@@ -2,23 +2,15 @@ require 'lhm/sql_retry'
 
 module Lhm
   class ChunkInsert
-    def initialize(migration, connection, lowest, highest, options = {})
+    def initialize(migration, connection, lowest, highest)
       @migration = migration
       @connection = connection
       @lowest = lowest
       @highest = highest
-      @retry_helper = SqlRetry.new(
-        @connection,
-        {
-          log_prefix: "Chunker Insert"
-        }.merge!(options.fetch(:retriable, {}))
-      )
     end
 
     def insert_and_return_count_of_rows_created
-      @retry_helper.with_retries do |retriable_connection|
-        retriable_connection.update sql
-      end
+      @connection.update sql
     end
 
     def sql

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -28,11 +28,12 @@ module Lhm
       @start = @chunk_finder.start
       @limit = @chunk_finder.limit
       @printer = options[:printer] || Printer::Percentage.new
+      @retry_options = options[:retriable] || {}
       @retry_helper = SqlRetry.new(
         @connection,
         {
           log_prefix: "Chunker"
-        }.merge!(options.fetch(:retriable, {}))
+        }.merge!(@retry_options)
       )
     end
 
@@ -46,7 +47,7 @@ module Lhm
         top = upper_id(@next_to_insert, stride)
         verify_can_run
 
-        affected_rows = ChunkInsert.new(@migration, @connection, bottom, top).insert_and_return_count_of_rows_created
+        affected_rows = ChunkInsert.new(@migration, @connection, bottom, top, @retry_options).insert_and_return_count_of_rows_created
         expected_rows = top - bottom + 1
 
         # Only log the chunker progress every 5 minutes instead of every iteration
@@ -78,7 +79,7 @@ module Lhm
     private
 
     def raise_on_non_pk_duplicate_warning
-      @connection.execute("show warnings").each do |level, code, message|
+      @connection.execute("show warnings", @retry_options).each do |level, code, message|
         unless message.match?(/Duplicate entry .+ for key 'PRIMARY'/)
           m = "Unexpected warning found for inserted row: #{message}"
           Lhm.logger.warn(m)
@@ -93,14 +94,14 @@ module Lhm
 
     def verify_can_run
       return unless @verifier
-      @retry_helper.with_retries do |retriable_connection|
+      @retry_helper.with_retries(@retry_options) do |retriable_connection|
         raise "Verification failed, aborting early" if !@verifier.call(retriable_connection)
       end
     end
 
     def upper_id(next_id, stride)
       sql = "select id from `#{ @migration.origin_name }` where id >= #{ next_id } order by id limit 1 offset #{ stride - 1}"
-      top = @connection.select_value(sql)
+      top = @connection.select_value(sql, @retry_options)
 
       [top ? top.to_i : @limit, @limit].min
     end

--- a/lib/lhm/connection.rb
+++ b/lib/lhm/connection.rb
@@ -1,15 +1,23 @@
+require 'delegate'
 
 module Lhm
-  class Connection
+  class Connection < SimpleDelegator
+
+    # Lhm::Connection inherits from SingleDelegator. It will forward any unknown method calls to the ActiveRecord
+    # connection.
+    alias connection __getobj__
+    alias connection= __setobj__
 
     def initialize(connection:, default_log_prefix: nil, retry_options: {})
       @default_log_prefix = default_log_prefix
-      @connection = connection
       @retry_options = retry_options || default_retry_config
       @sql_retry = Lhm::SqlRetry.new(
         connection,
         retry_options,
       )
+
+      # Creates delegation for the ActiveRecord Connection
+      super(connection)
     end
 
     def execute(query, retry_options = {})
@@ -24,24 +32,18 @@ module Lhm
       exec_with_retries(:select_value, query, retry_options)
     end
 
-    # Delegate ALL unknown method calls to ActiveRecord's connection.
-    # This ensures that there will be no breaking changes.
-    def method_missing(m, *args, &block)
-      @connection.public_send(m, *args, &block)
-    end
-
     private
 
     def exec_with_retries(method, sql, retry_options = {})
       retry_options[:log_prefix] ||= file
       @sql_retry.with_retries(retry_options) do |conn|
-        conn.send(method, sql)
+        conn.public_send(method, sql)
       end
     end
 
     # Returns camelized file name of caller (e.g. chunk_insert.rb -> ChunkInsert)
     def file
-      # check order
+      # Find calling file and extract name
       /[\/]*(\w+).rb:\d+:in/.match(relevant_caller)
       name = $1&.camelize || "Connection"
       "#{name}"
@@ -49,9 +51,11 @@ module Lhm
 
     def relevant_caller
       lhm_stack = caller.select { |x| x.include?("/lhm") }
+      first_candidate_index = lhm_stack.find_index {|line| !line.include?(__FILE__)}
 
       # Find the file that called the `#execute` (fallbacks to current file)
-      lhm_stack.at(3) || lhm_stack.first
+      return lhm_stack.first unless first_candidate_index
+      lhm_stack.at(first_candidate_index)
     end
   end
 end

--- a/lib/lhm/connection.rb
+++ b/lib/lhm/connection.rb
@@ -1,0 +1,66 @@
+require 'forwardable'
+require 'active_record'
+
+module Lhm
+  class Connection
+    extend Forwardable
+
+    # Defines methods to be forwarded to the ActiveRecord connection
+    begin
+      # ASK: There's a loading issue with this class even though the MySQL2 adapter isa the one used. Would there be anyway to do this but cleaner?
+      require 'active_record/connection_adapters/mysql2_adapter' unless defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
+
+      RETRIABLE_METHODS = [:update, :execute]
+      MODULES = [
+        ActiveRecord::ConnectionAdapters::DatabaseStatements,
+        ActiveRecord::ConnectionAdapters::SchemaStatements,
+        ActiveRecord::ConnectionAdapters::Mysql2Adapter
+      ]
+      methods = MODULES.flat_map(&:instance_methods).uniq - RETRIABLE_METHODS
+
+      def_delegators :@connection, *methods
+    end
+
+    def initialize(connection:, default_log_prefix: nil, retry_options: {})
+      @default_log_prefix = default_log_prefix
+      @connection = connection
+      @retry_options = retry_options || default_retry_config
+      @sql_retry = Lhm::SqlRetry.new(
+        connection,
+        retry_options,
+      )
+    end
+
+    def execute(query, retry_options = {})
+      exec_with_retries(:execute, query, retry_options)
+    end
+
+    def update(query, retry_options = {})
+      exec_with_retries(:update, query, retry_options)
+    end
+
+    private
+
+    def exec_with_retries(method, sql, retry_options = {})
+      retry_options[:log_prefix] ||= file
+      @sql_retry.with_retries(retry_options) do |conn|
+        conn.send(method, sql)
+      end
+    end
+
+    # returns humanized file of caller
+    def file
+      # check order
+      /[\/]*(\w+).rb:\d+:in/.match(relevant_caller)
+      name = $1&.camelize || "Connection"
+      "#{name}"
+    end
+
+    def relevant_caller
+      lhm_stack = caller.filter { |x| x.include?("/lhm") }
+
+      # Find the file that called the `#execute` (fallbacks to current file)
+      lhm_stack.at(3) || lhm_stack.first
+    end
+  end
+end

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -56,7 +56,7 @@ module Lhm
         Chunker.new(migration, @connection, options).run
         raise "Required triggers do not exist" unless triggers_still_exist?(@connection, entangler)
         if options[:atomic_switch]
-          AtomicSwitcher.new(migration, @connection, options).run
+          AtomicSwitcher.new(migration, @connection).run
         else
           LockedSwitcher.new(migration, @connection).run
         end

--- a/lib/lhm/sql_retry.rb
+++ b/lib/lhm/sql_retry.rb
@@ -21,8 +21,8 @@ module Lhm
     end
 
     def with_retries(retry_config = {})
-      @log_prefix = retry_config.delete(:log_prefix) || "SQL Retry"
       cnf = @global_retry_config.dup.merge!(retry_config)
+      @log_prefix = cnf.delete(:log_prefix) || "SQL Retry"
       Retriable.retriable(cnf) do
         yield(@connection)
       end

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -43,6 +43,7 @@ describe Lhm::AtomicSwitcher do
       log_messages = @logs.string.split("\n")
       assert_equal(2, log_messages.length)
       assert log_messages[0].include? "Starting run of class=Lhm::AtomicSwitcher"
+      # On failure of this assertion, check for Lhm::Connection#file
       assert log_messages[1].include? "[AtomicSwitcher] ActiveRecord::StatementInvalid: 'Lock wait timeout exceeded; try restarting transaction.' - 1 tries"
     end
 

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -6,6 +6,7 @@ require File.expand_path(File.dirname(__FILE__)) + '/integration_helper'
 require 'lhm/table'
 require 'lhm/migration'
 require 'lhm/atomic_switcher'
+require 'lhm/connection'
 
 describe Lhm::AtomicSwitcher do
   include IntegrationHelper
@@ -29,9 +30,11 @@ describe Lhm::AtomicSwitcher do
     end
 
     it 'should retry and log on lock wait timeouts' do
-      connection = mock()
-      connection.stubs(:data_source_exists?).returns(true)
-      connection.stubs(:execute).raises(ActiveRecord::StatementInvalid, 'Lock wait timeout exceeded; try restarting transaction.').then.returns(true)
+      ar_connection = mock()
+      ar_connection.stubs(:data_source_exists?).returns(true)
+      ar_connection.stubs(:execute).raises(ActiveRecord::StatementInvalid, 'Lock wait timeout exceeded; try restarting transaction.').then.returns(true)
+
+      connection = Lhm::Connection.new(connection: ar_connection)
 
       switcher = Lhm::AtomicSwitcher.new(@migration, connection, retriable: {base_interval: 0})
 
@@ -44,9 +47,11 @@ describe Lhm::AtomicSwitcher do
     end
 
     it 'should give up on lock wait timeouts after a configured number of tries' do
-      connection = mock()
-      connection.stubs(:data_source_exists?).returns(true)
-      connection.stubs(:execute).twice.raises(ActiveRecord::StatementInvalid, 'Lock wait timeout exceeded; try restarting transaction.')
+      ar_connection = mock()
+      ar_connection.stubs(:data_source_exists?).returns(true)
+      ar_connection.stubs(:execute).twice.raises(ActiveRecord::StatementInvalid, 'Lock wait timeout exceeded; try restarting transaction.')
+
+      connection = Lhm::Connection.new(connection: ar_connection)
 
       switcher = Lhm::AtomicSwitcher.new(@migration, connection, retriable: {tries: 2, base_interval: 0})
 
@@ -62,8 +67,10 @@ describe Lhm::AtomicSwitcher do
     end
 
     it "should raise when destination doesn't exist" do
-      connection = mock()
-      connection.stubs(:data_source_exists?).returns(false)
+      ar_connection = mock()
+      ar_connection.stubs(:data_source_exists?).returns(false)
+
+      connection = Lhm::Connection.new(connection: ar_connection)
 
       switcher = Lhm::AtomicSwitcher.new(@migration, connection)
 

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -54,7 +54,7 @@ module IntegrationHelper
   end
 
   def connect!(hostname, port, user, password)
-    adapter = ar_conn(hostname, port, user, password)
+    adapter = Lhm::Connection.new(connection: ar_conn(hostname, port, user, password))
     Lhm.setup(adapter)
     unless defined?(@@cleaned_up)
       Lhm.cleanup(true)

--- a/spec/unit/chunker_spec.rb
+++ b/spec/unit/chunker_spec.rb
@@ -38,11 +38,11 @@ describe Lhm::Chunker do
         5
       end
 
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 4/)).returns(7)
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 8 order by id limit 1 offset 4/)).returns(21)
-      @connection.expects(:update).with(regexp_matches(/between 1 and 7/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/between 8 and 10/)).returns(2)
-      @connection.expects(:execute).twice.with(regexp_matches(/show warnings/)).returns([])
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 4/),{}).returns(7)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 8 order by id limit 1 offset 4/),{}).returns(21)
+      @connection.expects(:update).with(regexp_matches(/between 1 and 7/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 8 and 10/),{}).returns(2)
+      @connection.expects(:execute).twice.with(regexp_matches(/show warnings/),{}).returns([])
 
       @chunker.run
     end
@@ -53,17 +53,17 @@ describe Lhm::Chunker do
         2
       end
 
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 1/)).returns(2)
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 3 order by id limit 1 offset 1/)).returns(4)
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 5 order by id limit 1 offset 1/)).returns(6)
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 7 order by id limit 1 offset 1/)).returns(8)
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 9 order by id limit 1 offset 1/)).returns(10)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 1/),{}).returns(2)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 3 order by id limit 1 offset 1/),{}).returns(4)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 5 order by id limit 1 offset 1/),{}).returns(6)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 7 order by id limit 1 offset 1/),{}).returns(8)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 9 order by id limit 1 offset 1/),{}).returns(10)
 
-      @connection.expects(:update).with(regexp_matches(/between 1 and 2/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/between 3 and 4/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/between 5 and 6/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/between 7 and 8/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/between 9 and 10/)).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 1 and 2/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 3 and 4/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 5 and 6/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 7 and 8/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 9 and 10/),{}).returns(2)
 
       @chunker.run
     end
@@ -80,17 +80,17 @@ describe Lhm::Chunker do
         end
       end
 
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 1/)).returns(2)
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 3 order by id limit 1 offset 2/)).returns(5)
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 6 order by id limit 1 offset 2/)).returns(8)
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 9 order by id limit 1 offset 2/)).returns(nil)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 1/),{}).returns(2)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 3 order by id limit 1 offset 2/),{}).returns(5)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 6 order by id limit 1 offset 2/),{}).returns(8)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 9 order by id limit 1 offset 2/),{}).returns(nil)
 
-      @connection.expects(:update).with(regexp_matches(/between 1 and 2/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/between 3 and 5/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/between 6 and 8/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/between 9 and 10/)).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 1 and 2/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 3 and 5/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 6 and 8/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 9 and 10/),{}).returns(2)
 
-      @connection.expects(:execute).twice.with(regexp_matches(/show warnings/)).returns([])
+      @connection.expects(:execute).twice.with(regexp_matches(/show warnings/),{}).returns([])
 
       @chunker.run
     end
@@ -100,8 +100,8 @@ describe Lhm::Chunker do
                                                            :start     => 1,
                                                            :limit     => 1)
 
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 0/)).returns(nil)
-      @connection.expects(:update).with(regexp_matches(/between 1 and 1/)).returns(1)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 0/),{}).returns(nil)
+      @connection.expects(:update).with(regexp_matches(/between 1 and 1/),{}).returns(1)
 
       @chunker.run
     end
@@ -114,17 +114,17 @@ describe Lhm::Chunker do
         2
       end
 
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 2 order by id limit 1 offset 1/)).returns(3)
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 4 order by id limit 1 offset 1/)).returns(5)
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 6 order by id limit 1 offset 1/)).returns(7)
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 8 order by id limit 1 offset 1/)).returns(9)
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 10 order by id limit 1 offset 1/)).returns(nil)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 2 order by id limit 1 offset 1/),{}).returns(3)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 4 order by id limit 1 offset 1/),{}).returns(5)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 6 order by id limit 1 offset 1/),{}).returns(7)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 8 order by id limit 1 offset 1/),{}).returns(9)
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 10 order by id limit 1 offset 1/),{}).returns(nil)
 
-      @connection.expects(:update).with(regexp_matches(/between 2 and 3/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/between 4 and 5/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/between 6 and 7/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/between 8 and 9/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/between 10 and 10/)).returns(1)
+      @connection.expects(:update).with(regexp_matches(/between 2 and 3/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 4 and 5/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 6 and 7/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 8 and 9/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/between 10 and 10/),{}).returns(1)
 
       @chunker.run
     end
@@ -138,9 +138,9 @@ describe Lhm::Chunker do
         2
       end
 
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 1/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/where \(foo.created_at > '2013-07-10' or foo.baz = 'quux'\) and `foo`/)).returns(1)
-      @connection.expects(:execute).with(regexp_matches(/show warnings/)).returns([])
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 1/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/where \(foo.created_at > '2013-07-10' or foo.baz = 'quux'\) and `foo`/),{}).returns(1)
+      @connection.expects(:execute).with(regexp_matches(/show warnings/),{}).returns([])
 
       def @migration.conditions
         "where foo.created_at > '2013-07-10' or foo.baz = 'quux'"
@@ -158,9 +158,9 @@ describe Lhm::Chunker do
         2
       end
 
-      @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 1/)).returns(2)
-      @connection.expects(:update).with(regexp_matches(/inner join bar on foo.id = bar.foo_id and/)).returns(1)
-      @connection.expects(:execute).with(regexp_matches(/show warnings/)).returns([])
+      @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 1/),{}).returns(2)
+      @connection.expects(:update).with(regexp_matches(/inner join bar on foo.id = bar.foo_id and/),{}).returns(1)
+      @connection.expects(:execute).with(regexp_matches(/show warnings/),{}).returns([])
 
       def @migration.conditions
         'inner join bar on foo.id = bar.foo_id'

--- a/spec/unit/chunker_spec.rb
+++ b/spec/unit/chunker_spec.rb
@@ -7,6 +7,7 @@ require 'lhm/table'
 require 'lhm/migration'
 require 'lhm/chunker'
 require 'lhm/throttler'
+require 'lhm/connection'
 
 describe Lhm::Chunker do
   include UnitHelper
@@ -41,7 +42,7 @@ describe Lhm::Chunker do
       @connection.expects(:select_value).with(regexp_matches(/where id >= 8 order by id limit 1 offset 4/)).returns(21)
       @connection.expects(:update).with(regexp_matches(/between 1 and 7/)).returns(2)
       @connection.expects(:update).with(regexp_matches(/between 8 and 10/)).returns(2)
-      @connection.expects(:query).twice.with(regexp_matches(/show warnings/)).returns([])
+      @connection.expects(:execute).twice.with(regexp_matches(/show warnings/)).returns([])
 
       @chunker.run
     end
@@ -89,7 +90,7 @@ describe Lhm::Chunker do
       @connection.expects(:update).with(regexp_matches(/between 6 and 8/)).returns(2)
       @connection.expects(:update).with(regexp_matches(/between 9 and 10/)).returns(2)
 
-      @connection.expects(:query).twice.with(regexp_matches(/show warnings/)).returns([])
+      @connection.expects(:execute).twice.with(regexp_matches(/show warnings/)).returns([])
 
       @chunker.run
     end
@@ -139,7 +140,7 @@ describe Lhm::Chunker do
 
       @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 1/)).returns(2)
       @connection.expects(:update).with(regexp_matches(/where \(foo.created_at > '2013-07-10' or foo.baz = 'quux'\) and `foo`/)).returns(1)
-      @connection.expects(:query).with(regexp_matches(/show warnings/)).returns([])
+      @connection.expects(:execute).with(regexp_matches(/show warnings/)).returns([])
 
       def @migration.conditions
         "where foo.created_at > '2013-07-10' or foo.baz = 'quux'"
@@ -159,7 +160,7 @@ describe Lhm::Chunker do
 
       @connection.expects(:select_value).with(regexp_matches(/where id >= 1 order by id limit 1 offset 1/)).returns(2)
       @connection.expects(:update).with(regexp_matches(/inner join bar on foo.id = bar.foo_id and/)).returns(1)
-      @connection.expects(:query).with(regexp_matches(/show warnings/)).returns([])
+      @connection.expects(:execute).with(regexp_matches(/show warnings/)).returns([])
 
       def @migration.conditions
         'inner join bar on foo.id = bar.foo_id'

--- a/spec/unit/connection_spec.rb
+++ b/spec/unit/connection_spec.rb
@@ -1,0 +1,68 @@
+require 'lhm/connection'
+
+describe Lhm::Connection do
+
+  LOCK_WAIT = ActiveRecord::StatementInvalid.new('Lock wait timeout exceeded; try restarting transaction.')
+
+  before(:each) do
+    @logs = StringIO.new
+    Lhm.logger = Logger.new(@logs)
+  end
+
+  it "Should find use calling file as prefix" do
+    ar_connection = mock()
+    ar_connection.stubs(:execute).raises(LOCK_WAIT).then.returns(true)
+
+    connection = Lhm::Connection.new(connection: ar_connection)
+
+    connection.execute("SHOW TABLES", { base_interval: 0 })
+
+    log_messages = @logs.string.split("\n")
+    assert_equal(1, log_messages.length)
+    assert log_messages.first.include?("[ConnectionSpec]")
+  end
+
+  it "#execute should be retried" do
+    ar_connection = mock()
+    ar_connection.stubs(:execute).raises(LOCK_WAIT)
+                 .then.raises(LOCK_WAIT)
+                 .then.returns(true)
+
+    connection = Lhm::Connection.new(connection: ar_connection)
+
+    connection.execute("SHOW TABLES", { base_interval: 0, tries: 3 })
+
+    log_messages = @logs.string.split("\n")
+    assert_equal(2, log_messages.length)
+  end
+
+  it "#update should be retried" do
+    ar_connection = mock()
+    ar_connection.stubs(:update).raises(LOCK_WAIT)
+                 .then.raises(LOCK_WAIT)
+                 .then.returns(1)
+
+    connection = Lhm::Connection.new(connection: ar_connection)
+
+    val = connection.update("SHOW TABLES", { base_interval: 0, tries: 3 })
+
+    log_messages = @logs.string.split("\n")
+    assert_equal val, 1
+    assert_equal(2, log_messages.length)
+  end
+
+  it "#select_value should be retried" do
+    ar_connection = mock()
+    ar_connection.stubs(:select_value).raises(LOCK_WAIT)
+                 .then.raises(LOCK_WAIT)
+                 .then.returns("dummy")
+
+    connection = Lhm::Connection.new(connection: ar_connection)
+
+    val = connection.select_value("SHOW TABLES", { base_interval: 0, tries: 3 })
+
+    log_messages = @logs.string.split("\n")
+    assert_equal val, "dummy"
+    assert_equal(2, log_messages.length)
+  end
+end


### PR DESCRIPTION
## Why?
Created an `Lhm::Connection` class to remove confusing logic and ensure that SQLRetry isn't passed around unnecessarily, rendering `@connection` useless. 

## How?
The `Lhm.setup(@connection)` creates an `Lhm::Connection` instance with the ActiveRecord connection. In order to make this change as non-breaking as possible, I thought of using mass-delegation instead of inheritance. The problem was that every method that is not "handled" by the new `Lhm::Connection` should be delegated to the ActiveRecord connection.

I had to improvise a way to do that, so I came up with `lib/connection.rb:9-22`. It's a bit convoluted but achieves what I was looking for quite well. I had to wrap it in a `begin-end` for internal ruby-specific reasons, but if anyone has any better idea, I am trying to make this **as clean and maintainable as possible**. 

TLDR (w.r.t `Lhm::Connection`); 
I get all the *relevant* instance methods used by ActiveRecord, remove the  "Object specific classes" (e.g. object_id, \_\_send\_\_, to_h, dup, etc.), remove the methods that should **NOT** be delegated (i.e. will contain some retry logic), then delegate them all to the `@connection` attribute.

Also, since now there's only one instance of `Lhm::SQLRetry`, the logging prefix was hard to manage. I whipped up a little something where I get the caller's file and `#camelise` it. It works really well and can be overridden by adding a log prefix explicitly.

## Focus
- Delegation process cleanliness
- I tried to be as "backwards compatible" as possible. So if you notice some edge-case or something that should now be deprecated, let me know.
- I had to change *some* logic in the test

### UPDATE:
The complex delegation has been changed to use `#method_missing` instead, as it drastically increases readability. 

