### PR TITLE
Bumping version to 3.5.1

### DIFF
--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = '3.5.0'
+  VERSION = '3.5.1'
 end


### PR DESCRIPTION
Bumping version to 3.5.1

This will include:
[LHM retry](https://github.com/Shopify/lhm/pull/112)
[ActiveRecord backwards compatible from 5.2 to 6.1.0](https://github.com/Shopify/lhm/pull/120)