### PR TITLE
[TEST] Removing ActiveSupport from Gemfile lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
-  activesupport
   after_do
   appraisal
   byebug


### PR DESCRIPTION
We've been encountering this error in the Build pipeline. This is a tentative at fixing this error:

Rational: 
Tried running `bundle install --deployment` on local machine to figure out the problem.
I ran `bundle install` followed by `bundle update` (which is the one triggering the Gemfile.lock update). This cleaned the lock file and hopefully this is enough to pass the CI tests.