### PR TITLE
Fixed regression with Lhm.connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 3.5.2 (Dec, 2021)
+* Fixed error on undefined connection, when calling `Lhm.connection` without calling `Lhm.setup` first
+* Changed `Lhm.connection.connection` to `lhm.connection.ar_connection` for increased clarity and readability
+
+# 3.5.1 (Dec , 2021)
+* Add better logging to the LHM components (https://github.com/Shopify/lhm/pull/112)
+* Slave lag throttler now supports ActiveRecord > 6.0
+* [Dev] Add `Appraisals` to test against multiple version
+
+# 3.5.0 (Dec , 2021)
+* Duplicate of 3.4.2 (unfortunate mistake)
+
+# 3.4.2 (Sept, 2021)
+* Fixed Chunker's undefined name error (https://github.com/Shopify/lhm/pull/110)
+
 # 3.4.1 (Sep 22, 2021)
 
 * Add better logging to the LHM components (https://github.com/Shopify/lhm/pull/108)

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,6 @@ Rake::TestTask.new('dev') do |t|
   t.libs << 'spec'
   t.test_files = FileList[
     'spec/test_helper.rb',
-    'spec/integration/lhm_spec.rb'
   #  Add file to test individually
   ]
   t.verbose = true

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -28,7 +28,7 @@ module Lhm
   extend Throttler
   extend self
 
-  DEFAULT_LOGGER_OPTIONS =  { level: Logger::INFO, file: STDOUT }
+  DEFAULT_LOGGER_OPTIONS = { level: Logger::INFO, file: STDOUT }
 
   # Alters a table with the changes described in the block
   #
@@ -99,12 +99,13 @@ module Lhm
   # @option connection_options [Boolean] :reconnect_with_consistent_host
   #   Active / Deactivate ProxySQL-aware reconnection procedure (default to: false)
   def connection(connection_options = nil)
-    if @@connection.nil?
+    @@connection ||= begin
       raise 'Please call Lhm.setup' unless defined?(ActiveRecord)
       @@connection = Connection.new(connection: ActiveRecord::Base.connection, options: connection_options || {})
-    else
-      @@connection.options = connection_options unless connection_options.nil?
     end
+
+    @@connection.process_connection_options(connection_options) unless connection_options.nil?
+
     @@connection
   end
 

--- a/lib/lhm/chunk_insert.rb
+++ b/lib/lhm/chunk_insert.rb
@@ -3,12 +3,12 @@ require 'lhm/proxysql_helper'
 
 module Lhm
   class ChunkInsert
-    def initialize(migration, connection, lowest, highest, options = {})
+    def initialize(migration, connection, lowest, highest, retry_options = {})
       @migration = migration
       @connection = connection
       @lowest = lowest
       @highest = highest
-      @retry_options = options[:retriable] || {}
+      @retry_options = retry_options
     end
 
     def insert_and_return_count_of_rows_created

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -31,7 +31,7 @@ module Lhm
       @retry_options = options[:retriable] || {}
       @retry_helper = SqlRetry.new(
         @connection,
-        options: {
+        retry_options: {
           log_prefix: "Chunker"
         }.merge!(@retry_options)
       )

--- a/lib/lhm/sql_retry.rb
+++ b/lib/lhm/sql_retry.rb
@@ -28,10 +28,10 @@ module Lhm
     # This internal error is used to trigger retries from the parent Retriable.retriable in #with_retries
     class ReconnectToHostSuccessful < Lhm::Error; end
 
-    def initialize(connection, options: {}, reconnect_with_consistent_host: true)
+    def initialize(connection, retry_options: {}, reconnect_with_consistent_host: false)
       @connection = connection
-      @log_prefix = options.delete(:log_prefix)
-      @global_retry_config = default_retry_config.dup.merge!(options)
+      @log_prefix = retry_options.delete(:log_prefix)
+      @global_retry_config = default_retry_config.dup.merge!(retry_options)
       if (@reconnect_with_consistent_host = reconnect_with_consistent_host)
         @initial_hostname = hostname
         @initial_server_id = server_id
@@ -63,7 +63,7 @@ module Lhm
     end
 
     attr_reader :global_retry_config
-    attr_accessor :reconnect_with_consistent_host
+    attr_accessor :connection, :reconnect_with_consistent_host
 
     private
 

--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = '3.5.1'
+  VERSION = '3.5.2'
 end

--- a/spec/integration/sql_retry/lock_wait_spec.rb
+++ b/spec/integration/sql_retry/lock_wait_spec.rb
@@ -55,7 +55,7 @@ describe Lhm::SqlRetry do
   it "successfully executes the SQL despite the errors encountered" do
     # Start a thread to retry, once the lock is held, execute the block
     @helper.with_waiting_lock do |waiting_connection|
-      sql_retry = Lhm::SqlRetry.new(waiting_connection, options: {
+      sql_retry = Lhm::SqlRetry.new(waiting_connection, retry_options: {
         base_interval: 0.2, # first retry after 200ms
         multiplier: 1, # subsequent retries wait 1x longer than first retry (no change)
         tries: 3, # we only need 3 tries (including the first) for the scenario described below
@@ -98,7 +98,7 @@ describe Lhm::SqlRetry do
     puts "*" * 64
     # Start a thread to retry, once the lock is held, execute the block
     @helper.with_waiting_lock do |waiting_connection|
-      sql_retry = Lhm::SqlRetry.new(waiting_connection, options: {
+      sql_retry = Lhm::SqlRetry.new(waiting_connection, retry_options: {
         base_interval: 0.2, # first retry after 200ms
         multiplier: 1, # subsequent retries wait 1x longer than first retry (no change)
         tries: 2, # we need 3 tries (including the first) for the scenario described below, but we only get two...we will fail

--- a/spec/integration/sql_retry/retry_with_proxysql_spec.rb
+++ b/spec/integration/sql_retry/retry_with_proxysql_spec.rb
@@ -18,7 +18,7 @@ describe Lhm::SqlRetry, "ProxiSQL tests for LHM retry" do
 
     @connection = DBConnectionHelper::new_mysql_connection(:proxysql, true, true)
 
-    @lhm_retry = Lhm::SqlRetry.new(@connection, options: {},
+    @lhm_retry = Lhm::SqlRetry.new(@connection, retry_options: {},
                                    reconnect_with_consistent_host: true)
   end
 
@@ -63,7 +63,7 @@ describe Lhm::SqlRetry, "ProxiSQL tests for LHM retry" do
     Lhm::SqlRetry.any_instance.stubs(:hostname).returns("mysql-1").then.returns("mysql-2")
 
     # Need new instance for stub to take into effect
-    lhm_retry = Lhm::SqlRetry.new(@connection, options: {},
+    lhm_retry = Lhm::SqlRetry.new(@connection, retry_options: {},
                                   reconnect_with_consistent_host: true)
 
     e = assert_raises Lhm::Error do

--- a/spec/unit/lhm_spec.rb
+++ b/spec/unit/lhm_spec.rb
@@ -26,4 +26,21 @@ describe Lhm do
       value(Lhm.logger.instance_eval { @logdev }.dev.path).must_equal 'omg.ponies'
     end
   end
+
+  describe 'api' do
+
+    before(:each) do
+      @connection = mock()
+    end
+
+    it 'should create a new connection when calling setup' do
+      Lhm.setup(@connection)
+      value(Lhm.connection).must_be_kind_of(Lhm::Connection)
+    end
+
+    it 'should create a new connection when none is created' do
+      ActiveRecord::Base.stubs(:connection).returns(@connection)
+      value(Lhm.connection).must_be_kind_of(Lhm::Connection)
+    end
+  end
 end


### PR DESCRIPTION
A regression was introduced where calling `Lhm.connection` would error when used before calling `Lhm.setup`. 
This fix can be found at `lib/lhm.rb:102`.

I added some tests to ensure that the LHM API would not experience further regressions

This led to a minor refactor of some other pieces of code that were excessively confusing.
This included renaming `options` to `retry_options` in the `Lhm::SqlRetry initializer` and added some logic to be able to hot-swap the ActiveRecord connection in `Lhm::Connection` without having to create a new one.