### PR TITLE
Changed version in Gemfile.lock to use lhm-shopify 3.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lhm-shopify (3.5.1)
+    lhm-shopify (3.5.2)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_5.2.gemfile.lock
+++ b/gemfiles/activerecord_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (3.5.1)
+    lhm-shopify (3.5.2)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_6.0.gemfile.lock
+++ b/gemfiles/activerecord_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (3.5.1)
+    lhm-shopify (3.5.2)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_6.1.gemfile.lock
+++ b/gemfiles/activerecord_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (3.5.1)
+    lhm-shopify (3.5.2)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_7.0.0.alpha2.gemfile.lock
+++ b/gemfiles/activerecord_7.0.0.alpha2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (3.5.1)
+    lhm-shopify (3.5.2)
       retriable (>= 3.0.0)
 
 GEM


### PR DESCRIPTION
Version mismatch caused Shipit to not publish the gem.