### PR TITLE
Changed ProxySQL annotation order + bump to 3.5.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lhm-shopify (3.5.2)
+    lhm-shopify (3.5.3)
       retriable (>= 3.0.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -301,6 +301,15 @@ COV=1 bundle exec rake unit && bundle exec rake integration
 open coverage/index.html
 ```
 
+### Merging for a new version
+When creating a PR for a new version, make sure that th version has been bumped in `lib/lhm/version.rb`. Then run the following code snippet to ensure the everything is consistent, otherwise 
+the gem will not publish.
+```bash
+bundle install
+bundle update
+bundle exec appraisals install
+```
+
 ### Docker Compose
 The integration tests rely on a replication configuration for MySQL which is being proxied by an instance of ProxySQL.
 It is important that every container is running to execute the integration test suite.

--- a/gemfiles/activerecord_5.2.gemfile.lock
+++ b/gemfiles/activerecord_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (3.5.2)
+    lhm-shopify (3.5.3)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_6.0.gemfile.lock
+++ b/gemfiles/activerecord_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (3.5.2)
+    lhm-shopify (3.5.3)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_6.1.gemfile.lock
+++ b/gemfiles/activerecord_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (3.5.2)
+    lhm-shopify (3.5.3)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_7.0.0.alpha2.gemfile.lock
+++ b/gemfiles/activerecord_7.0.0.alpha2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (3.5.2)
+    lhm-shopify (3.5.3)
       retriable (>= 3.0.0)
 
 GEM

--- a/lib/lhm/proxysql_helper.rb
+++ b/lib/lhm/proxysql_helper.rb
@@ -4,7 +4,7 @@ module Lhm
     ANNOTATION = "/*maintenance:lhm*/"
 
     def tagged(sql)
-      "#{ANNOTATION}#{sql}"
+      "#{sql} #{ANNOTATION}"
     end
   end
 end

--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = '3.5.2'
+  VERSION = '3.5.3'
 end

--- a/spec/integration/proxysql_spec.rb
+++ b/spec/integration/proxysql_spec.rb
@@ -29,6 +29,6 @@ describe "ProxySQL integration" do
       port: "33005",
       )
 
-    assert_equal conn.query("/*maintenance:lhm*/SELECT @@global.hostname as host").each.first["host"], "mysql-1"
+    assert_equal conn.query("SELECT @@global.hostname as host #{Lhm::ProxySQLHelper::ANNOTATION}").each.first["host"], "mysql-1"
   end
 end

--- a/spec/unit/connection_spec.rb
+++ b/spec/unit/connection_spec.rb
@@ -73,7 +73,7 @@ describe Lhm::Connection do
 
   it "Queries should be tagged with ProxySQL tag if requested" do
     ar_connection = mock()
-    ar_connection.expects(:public_send).with(:select_value, "#{Lhm::ProxySQLHelper::ANNOTATION}SHOW TABLES").returns("dummy")
+    ar_connection.expects(:public_send).with(:select_value, "SHOW TABLES #{Lhm::ProxySQLHelper::ANNOTATION}").returns("dummy")
     ar_connection.stubs(:execute).times(4).returns([["dummy"]])
     ar_connection.stubs(:active?).returns(true)
 


### PR DESCRIPTION
Some internal tools have some requirements that an SQL query cannot start with a comment. Therefore, the tagging of the queries for ProxySQL have been changed to be after the query itself. 

Also added some documentation for gem upgrades for next contributors.