### PR TITLE
Fix thread throttler #stride API

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ throttle based on the number of threads running in MySQL, as a proxy for "is
 this operation causing excessive load":
 
 ```ruby
+my_throttler = Lhm::Throttler::ThreadsRunning.new(stride: 100_000)
+
+Lhm.change_table :users, throttler: my_throttler  do |m|
+  ...
+end
+
+# or use default settings:
 Lhm.change_table :users, throttler: :threads_running_throttler do |m|
   ...
 end

--- a/lib/lhm/throttler/threads_running.rb
+++ b/lib/lhm/throttler/threads_running.rb
@@ -3,14 +3,16 @@ module Lhm
     class ThreadsRunning
       include Command
 
+      DEFAULT_STRIDE = 2_000
       DEFAULT_INITIAL_TIMEOUT = 0.1
       DEFAULT_HEALTHY_RANGE = (0..50)
 
-      attr_accessor :timeout_seconds, :healthy_range, :connection
+      attr_accessor :timeout_seconds, :healthy_range, :connection, :stride
       attr_reader :max_timeout_seconds, :initial_timeout_seconds
 
       def initialize(options = {})
         @initial_timeout_seconds = options[:initial_timeout] || DEFAULT_INITIAL_TIMEOUT
+        @stride = options[:stride] || DEFAULT_STRIDE
         @max_timeout_seconds = options[:max_timeout] || (@initial_timeout_seconds * 1024)
         @timeout_seconds = @initial_timeout_seconds
         @healthy_range = options[:healthy_range] || DEFAULT_HEALTHY_RANGE

--- a/spec/unit/throttler/threads_running_spec.rb
+++ b/spec/unit/throttler/threads_running_spec.rb
@@ -9,6 +9,24 @@ describe Lhm::Throttler::ThreadsRunning do
     @throttler = Lhm::Throttler::ThreadsRunning.new
   end
 
+  describe '#stride' do
+    describe 'default value' do
+      it 'is present' do
+        assert_equal(@throttler.stride, 2_000)
+      end
+    end
+
+    describe 'when set by user' do
+      before do
+        @throttler = Lhm::Throttler::ThreadsRunning.new(stride: 100_500)
+      end
+
+      it 'returns that value' do
+        assert_equal(@throttler.stride, 100_500)
+      end
+    end
+  end
+
   describe '#throttle_seconds' do
     describe 'with no mysql activity' do
       before do


### PR DESCRIPTION
`Lhm::Throttler::ThreadsRunning` was missing the `#stride` method, which this PR fixes.
Tests and more usage examples were added as well.