### PR TITLE
Added platform stanza for Percona images in docker-compose

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-linux
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   mysql-1:
     container_name: mysql-1
     image: percona:5.7
+    platform: linux/amd64
     command:
       --server-id=1
       --log-bin
@@ -23,6 +24,7 @@ services:
   mysql-2:
     container_name: mysql-2
     image: percona:5.7
+    platform: linux/amd64
     command:
       --server-id=2
       --log-bin

--- a/gemfiles/activerecord_5.2.gemfile.lock
+++ b/gemfiles/activerecord_5.2.gemfile.lock
@@ -45,6 +45,7 @@ GEM
       thread_safe (~> 0.1)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/gemfiles/activerecord_6.0.gemfile.lock
+++ b/gemfiles/activerecord_6.0.gemfile.lock
@@ -47,6 +47,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-linux
 

--- a/gemfiles/activerecord_6.1.gemfile.lock
+++ b/gemfiles/activerecord_6.1.gemfile.lock
@@ -46,6 +46,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-linux
 

--- a/gemfiles/activerecord_7.0.0.alpha2.gemfile.lock
+++ b/gemfiles/activerecord_7.0.0.alpha2.gemfile.lock
@@ -44,6 +44,7 @@ GEM
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-linux
 


### PR DESCRIPTION
### Problem
`dev up` was failing following the transition to M1 Macbook Pros at the `docker pull` stage.

### Fix
Added the stanza `platform: linux/amd64` for Percona services in `docker-compose.yml`. This ensures that the containers will be emulated with the right binaries (some performance hit but nothing too noticeable).

### Changes
- `docker-compose.yml`
- The `Gemfiles-<version>.lock` added the `arm64-darwin` as a platform after running `dev up` on my machine. This will probably happen as new contributors pick up the project, so I decided to leave it

### New Gem version required
No