### PR TITLE
LHM printer.notify(current_pk, max_pk, {bytes_copied: ..., total_bytes: ..., copy_speed: ...})

### DIFF
--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -11,6 +11,89 @@ module Lhm
     include Command
     include SqlHelper
 
+    # Keeps track of the speed by performing linear regression on the data on
+    # the last X minutes.
+    class Speedometer
+      attr_reader :log
+
+      def self.linregress(x, y)
+        raise ArgumentError, "x and y not the same length" if x.length != y.length
+
+        n = x.length
+        xsum = 0
+        ysum = 0
+        xxsum = 0
+        yysum = 0
+        xysum = 0
+
+        n.times do |i|
+          xsum += x[i]
+          ysum += y[i]
+          xxsum += x[i] ** 2
+          yysum += y[i] ** 2
+          xysum += x[i] * y[i]
+        end
+
+        denom = (n * xxsum - xsum ** 2)
+        if denom == 0
+          return [0, 0, true]
+        end
+
+        slope = (n * xysum - xsum * ysum) / denom
+        intercept = ysum / n - slope * xsum / n
+
+        [slope, intercept, false]
+      end
+
+      def initialize(window, initial_value = 0)
+        # log is just a list of [time, f(time)]
+        @log = []
+
+        # window is the window duration in seconds. Data outside of this window
+        # will be discarded as more comes in.
+        @window = window
+
+        self << initial_value
+      end
+
+      def <<(ft)
+        now = Time.now
+        @log << [now, ft]
+
+        # Find the first data point that's in the window. This data point may
+        # be very close to the current time and therefore the majority of the
+        # timed window may not have any data points in it.
+        #
+        # If we discarded all data points before this data point, the window is
+        # thus more biased towards the present and hence may be an
+        # over-estimate of the current speed. Thus, we keep just one data point
+        # before of the window.
+        i = @log.find_index { |l| now - l[0] < @window }
+        i -= 1 if i > 0
+        @log = @log[i..-1]
+      end
+
+      def speed
+        return nil if @log.length < 2
+
+        x = []
+        y = []
+
+        # Normalize all time entry to 0 otherwise it'll be too large and cause
+        # wide inaccuracy.
+        first_time = @log[0][0]
+
+        @log.each do |entry|
+          x << entry[0] - first_time
+          y << entry[1]
+        end
+
+        slope, _, singular = self.class.linregress(x, y)
+        return nil if singular
+        slope
+      end
+    end
+
     attr_reader :connection
 
     LOG_PREFIX = "Chunker"
@@ -35,25 +118,29 @@ module Lhm
         @connection,
         retry_options: @retry_options
       )
+      @speedometer_window = options[:speedometer_window] || 5 * 60
     end
 
     def execute
       @start_time = Time.now
 
       return if @chunk_finder.table_empty?
-      @next_to_insert = @start
-      while @next_to_insert <= @limit || (@start == @limit)
+      speedometer = Speedometer.new(@speedometer_window)
+
+      next_to_insert = @start
+      bytes_copied = 0
+      while next_to_insert <= @limit || (@start == @limit)
         stride = @throttler.stride
-        top = upper_id(@next_to_insert, stride)
+        top = upper_id(next_to_insert, stride)
         verify_can_run
 
-        affected_rows = ChunkInsert.new(@migration, @connection, bottom, top, @retry_options).insert_and_return_count_of_rows_created
-        expected_rows = top - bottom + 1
+        affected_rows = ChunkInsert.new(@migration, @connection, next_to_insert, top, @retry_options).insert_and_return_count_of_rows_created
+        expected_rows = top - next_to_insert + 1
 
         # Only log the chunker progress every 5 minutes instead of every iteration
         current_time = Time.now
         if current_time - @start_time > (5 * 60)
-          Lhm.logger.info("Inserted #{affected_rows} rows into the destination table from #{bottom} to #{top}")
+          Lhm.logger.info("Inserted #{affected_rows} rows into the destination table from #{next_to_insert} to #{top}")
           @start_time = current_time
         end
 
@@ -61,13 +148,24 @@ module Lhm
           raise_on_non_pk_duplicate_warning
         end
 
+        p = progress
+
+        additional_info = {
+          total_bytes: p[0],
+          bytes_copied: p[1],
+        }
+
+        bytes_copied += additional_info[:bytes_copied]
+        speedometer << bytes_copied
+        additional_info[:copy_speed] = speedometer.speed
+
+        @printer.notify(next_to_insert, @limit, additional_info)
+
         if @throttler && affected_rows > 0
           @throttler.run
         end
 
-        @next_to_insert = top + 1
-        @printer.notify(bottom, @limit)
-
+        next_to_insert = top + 1
         break if @start == @limit
       end
       @printer.end
@@ -88,14 +186,25 @@ module Lhm
       end
     end
 
-    def bottom
-      @next_to_insert
-    end
-
     def verify_can_run
       return unless @verifier
       @retry_helper.with_retries(log_prefix: LOG_PREFIX) do |retriable_connection|
         raise "Verification failed, aborting early" if !@verifier.call(retriable_connection)
+      end
+    end
+
+    def progress
+      query = %W{
+        SELECT
+          (origin_table.data_length + origin_table.index_length) AS origin_size,
+          (destination_table.data_length + destination_table.index_length) as destination_size
+        FROM information_schema.tables AS destination_table
+        JOIN information_schema.tables AS origin_table
+          ON origin_table.table_name = '#{@migration.origin_name}'
+        WHERE destination_table.table_name = '#{@migration.destination_name}'
+      }
+      @retry_helper.with_retries do |retriable_connection|
+        retriable_connection.select_rows(query.join(' ')).first
       end
     end
 

--- a/lib/lhm/printer.rb
+++ b/lib/lhm/printer.rb
@@ -17,16 +17,16 @@ module Lhm
         @max_length = 0
       end
 
-      def notify(lowest, highest)
-        return if !highest || highest == 0
+      def notify(current_pk, max_pk, additional_info = {})
+        return if !max_pk || max_pk == 0
 
-        # The argument lowest represents the next_to_insert row id, and highest represents the 
-        # maximum id upto which chunker has to copy the data. 
-        # If all the rows are inserted upto highest, then lowest passed here from chunker was 
-        # highest + 1, which leads to the printer printing the progress > 100%.
-        return if lowest >= highest
-        
-        message = "%.2f%% (#{lowest}/#{highest}) complete" % (lowest.to_f / highest * 100.0)
+        # The argument current_pk represents the next_to_insert row id, and max_pk represents the
+        # maximum id upto which chunker has to copy the data.
+        # If all the rows are inserted upto max_pk, then current_pk passed here from chunker was
+        # max_pk + 1, which leads to the printer printing the progress > 100%.
+        return if current_pk >= max_pk
+
+        message = "%.2f%% (#{current_pk}/#{max_pk}) complete" % (current_pk.to_f / max_pk * 100.0)
         write(message)
       end
 

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -137,7 +137,7 @@ describe Lhm::Chunker do
       23.times { |n| execute("insert into origin set id = '#{ n * n + 23 }'") }
 
       printer = MiniTest::Mock.new
-      printer.expect(:notify, :return_value, [Integer, Integer])
+      printer.expect(:notify, :return_value, [Integer, Integer, Hash])
       printer.expect(:end, :return_value, [])
 
       Lhm::Chunker.new(
@@ -170,7 +170,7 @@ describe Lhm::Chunker do
       23.times { |n| execute("insert into origin set id = '#{ 100000 + n * n + 23 }'") }
 
       printer = MiniTest::Mock.new
-      printer.expect(:notify, :return_value, [Integer, Integer])
+      printer.expect(:notify, :return_value, [Integer, Integer, Hash])
       printer.expect(:end, :return_value, [])
 
       Lhm::Throttler::Slave.any_instance.stubs(:slave_hosts).returns(['127.0.0.1'])
@@ -191,7 +191,7 @@ describe Lhm::Chunker do
       15.times { |n| execute("insert into origin set id = '#{ (n * n) + 1 }'") }
 
       printer = mock()
-      printer.expects(:notify).with(instance_of(Integer), instance_of(Integer)).twice
+      printer.expects(:notify).with(instance_of(Integer), instance_of(Integer), instance_of(Hash)).twice
       printer.expects(:end)
 
       throttler = Lhm::Throttler::SlaveLag.new(stride: 10, allowed_lag: 0)
@@ -214,7 +214,7 @@ describe Lhm::Chunker do
       15.times { |n| execute("insert into origin set id = '#{ (n * n) + 1 }'") }
 
       printer = mock()
-      printer.expects(:notify).with(instance_of(Integer), instance_of(Integer)).twice
+      printer.expects(:notify).with(instance_of(Integer), instance_of(Integer), instance_of(Hash)).twice
       printer.expects(:verify)
       printer.expects(:end)
 


### PR DESCRIPTION
I'm trying to revive #83. Description from the original PR:

>Using the primary key to track progress works very poorly if the PKs are non-uniformly distributed.
>
>This PR changes the `printer.notify` interface to emit three more numbers: 
>
>1. Number of bytes copied in the `lhmn_` table given by `information_schemas.TABLES`. This is the `bytes_copied` parameter.
>2. Number of bytes in the original table given by `information_schema.TABLES`. This is the `total_bytes` parameter.
>3. The current speed of copy as estimated via linear regression with the aforementioned numbers over the last X minutes.
>
>We should be able to use this to get a more accurate progress/ETA, although if the chunker loop can block for ~1 hr, the accuracy remains doubtful. Additionally, there is a possibility that the addition/removal of a column/index will drastically alter the size of the table, which may make the progress in accurate. Example: if the data increases by 20% after a LHM, the progress will get to a maximum of 80%. Conversely, if the data decreases by 20% after a LHM, the progress will get to a maximum of 120%.
>
>Test coverage of the printer interface is not great. That said the speed calculation does have some basic tests.