### PR TITLE
Allow configuration to skip the `execute_inline!` call

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ end
 to prevent accidental data loss. After successful or failed LHM migrations, these leftover
 tables must be cleaned up.
 
+**Note:** When developing locally or running tests, LHM runs 'inline' by default, meaning that the
+extra table is not used and the original table is not replaced. If this behavior is not desirable
+for your project, you can disable it by setting `Lhm.disallow_inline!` in the appropriate
+environment file or initializer.
+
 ### Usage with ProxySQL
 LHM can recover from connection loss. However, when used in conjunction with ProxySQL, there are multiple ways that
 connection loss could induce data loss (if triggered by a failover). Therefore  it will perform additional checks to

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -116,6 +116,18 @@ module Lhm
       end
   end
 
+  @@disallow_inline = false
+
+  # Use to control the inline-execution of Lhm migrations - by default migrations are inlined
+  # in test and development environments, and in some cases that's not desireable.
+  def self.disallow_inline!
+    @@disallow_inline = true
+  end
+
+  def self.inline_allowed?
+    !@@disallow_inline
+  end
+
   private
 
   def drop_tables_and_triggers(run = false, triggers, tables)

--- a/lib/lhm/railtie.rb
+++ b/lib/lhm/railtie.rb
@@ -2,7 +2,7 @@ module Lhm
   class Railtie < Rails::Railtie
     initializer "lhm.test_setup" do
       if Rails.env.test? || Rails.env.development?
-        Lhm.execute_inline!
+        Lhm.execute_inline! if Lhm.inline_allowed?
       end
     end
   end


### PR DESCRIPTION
# Purpose
Since updating to lhm-shopify, we had a recurring issue where people would write a migration using LHM (we have it in our generator templates), but fill it with normal calls to migration methods like `add_column(:tablename, :colname, :string)`. 

Before the upgrade, these calls would get caught immediately, because the schema file wouldn't get the intended changes, and any staging stack based on that branch would not have the column present.  But after the upgrade, these calls _worked fine_ locally, and since our staging stacks are based on the schema file (not by running migrations from scratch), we only end up catching these problems in production.

When we realized what was happening, we tracked it to [here](https://github.com/Shopify/lhm/blob/master/lib/lhm/railtie.rb#L4-L5) - the explanations on the change make total sense, but in our case we'd much rather exclude `development` from inlining, so this problem will get caught locally. (You should probably consider dropping the `development?` condition entirely - I expect other people are getting surprised here occasionally as well).

# Implementation
* Update the README to note the new configuration option, without going into much detail about why you'd care
* Add `Lhm.disallow_inline!` and `Lhm.inline_allowed?` to the base module for configuration purposes
* Add an extra check against `Lhm.inline_allowed?` to the Railtie. Didn't see any tests on this thing, but I'm happy to go learn how to make one if you'd like.

# Verification
Confirmed locally that with the setting not supplied migrations run inline, and with `Lhm.disallow_inline!` called, they do not.

## Note
If you'd rather drop the 'auto-inline in development' part, that's a smaller change, and I'd be happy to update the PR :-)
