### PR TITLE
Add support for tables with generated columns

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-20
   x86_64-linux
 

--- a/lib/lhm/intersection.rb
+++ b/lib/lhm/intersection.rb
@@ -4,10 +4,11 @@
 module Lhm
   #  Determine and format columns common to origin and destination.
   class Intersection
-    def initialize(origin, destination, renames = {})
+    def initialize(origin, destination, renames = {}, generated_column_names = [])
       @origin = origin
       @destination = destination
       @renames = renames
+      @generated_column_names = generated_column_names
     end
 
     def origin
@@ -21,7 +22,7 @@ module Lhm
     private
 
     def common
-      (@origin.columns.keys & @destination.columns.keys).sort
+      ((@origin.columns.keys & @destination.columns.keys) - @generated_column_names).sort
     end
 
     module Joiners

--- a/lib/lhm/migration.rb
+++ b/lib/lhm/migration.rb
@@ -8,12 +8,13 @@ module Lhm
   class Migration
     attr_reader :origin, :destination, :conditions, :renames
 
-    def initialize(origin, destination, conditions = nil, renames = {}, time = Time.now)
+    def initialize(origin, destination, conditions = nil, renames = {}, time = Time.now, generated_column_names = [])
       @origin = origin
       @destination = destination
       @conditions = conditions
       @renames = renames
       @table_name = TableName.new(@origin.name, time)
+      @generated_column_names = generated_column_names
     end
 
     def archive_name
@@ -21,7 +22,7 @@ module Lhm
     end
 
     def intersection
-      Intersection.new(@origin, @destination, @renames)
+      Intersection.new(@origin, @destination, @renames, @generated_column_names)
     end
 
     def origin_name

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -206,7 +206,11 @@ module Lhm
       @statements.each do |stmt|
         @connection.execute(tagged(stmt))
       end
-      Migration.new(@origin, destination_read, conditions, renames)
+      Migration.new(@origin, destination_read, conditions, renames, Time.now, generated_column_names)
+    end
+
+    def generated_column_names
+      @connection.columns(@origin.name).select(&:virtual?).map(&:name)
     end
 
     def destination_create


### PR DESCRIPTION
Currently if a table has any [generated columns](https://dev.mysql.com/doc/refman/8.0/en/create-table-generated-columns.html), the migration will fail as the Migrator will attempt to "write" to the generated column. This PR removes the columns from Intersection#common column names to prevent the write.