### PR TITLE
Bump version to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Unreleased
+
+# 4.0.0 (Sep, 2023)
 * Deprecate `SlaveLag` throttler class name. Use `ReplicaLag` instead (https://github.com/Shopify/lhm/pull/144)
 * Deprecate `slave_lag_throttler` throttler config value. Use `replica_lag_throttler` instead (https://github.com/Shopify/lhm/pull/144)
 * Fix errors when creating indexes with whitespace between column names and sizes. (https://github.com/Shopify/lhm/pull/145)
 * Test against Ruby 3.2 and Rails 7.1.0.beta1. (https://github.com/Shopify/lhm/pull/146)
 * Drop support for Ruby 2 and Rails 5. (https://github.com/Shopify/lhm/pull/148)
+* Fix Fix thread throttler #stride API. (https://github.com/Shopify/lhm/pull/131)
 
 # 3.5.5 (Jan, 2022)
 * Fix error where from Config shadowing which would cause LHM to abort on reconnect (https://github.com/Shopify/lhm/pull/128)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lhm-shopify (3.5.5)
+    lhm-shopify (4.0.0)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_6.0.gemfile.lock
+++ b/gemfiles/activerecord_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (3.5.5)
+    lhm-shopify (4.0.0)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_6.1.gemfile.lock
+++ b/gemfiles/activerecord_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (3.5.5)
+    lhm-shopify (4.0.0)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_7.0.gemfile.lock
+++ b/gemfiles/activerecord_7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (3.5.5)
+    lhm-shopify (4.0.0)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_7.1.0.beta1.gemfile.lock
+++ b/gemfiles/activerecord_7.1.0.beta1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (3.5.5)
+    lhm-shopify (4.0.0)
       retriable (>= 3.0.0)
 
 GEM

--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = '3.5.5'
+  VERSION = '4.0.0'
 end


### PR DESCRIPTION
Preparing a new release. Bumping the major version since we're dropping support for older versions of Ruby and Rails.