### PR TITLE
Trilogy returns a hash instead of Array (mysql2) - WIP

### DIFF
--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -41,7 +41,13 @@ module Lhm
       def ddl
         sql = "show create table `#{ @table_name }`"
         specification = nil
-        @connection.execute(sql).each { |row| specification = row.last }
+        @connection.execute(sql).each do |row|
+          specification = if row.is_a?(Hash)
+            row.values.last
+          else
+            row.last
+          end
+        end
         specification
       end
 


### PR DESCRIPTION


```
Caused by:
NoMethodError: undefined method `last' for {"Table"=>"billing_transactions", "Create Table"=>"CREATE TABLE `billing_transactions` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `reason_id` bigint DEFAULT NULL,\n  `reason_type` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci DEFAULT NULL,\n  `billing_parent_id` bigint DEFAULT NULL,\n  `billing_parent_type` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci DEFAULT NULL,\n  `billing_account_id` bigint DEFAULT NULL,\n  `amount` decimal(10,2) DEFAULT NULL,\n  `description` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci,\n  `recorded_at` datetime DEFAULT NULL,\n  `effective_at` datetime DEFAULT NULL,\n  `started_at` datetime DEFAULT NULL,\n  `ended_at` datetime DEFAULT NULL,\n  `created_at` datetime NOT NULL,\n  `updated_at` datetime NOT NULL,\n  `category_key` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci DEFAULT NULL,\n  `business_id` bigint DEFAULT NULL,\n  `invoice_id` bigint DEFAULT NULL,\n  `is_not_deleted` tinyint(1) DEFAULT '1',\n  `deleted_at` datetime DEFAULT NULL,\n  `subcategory` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci DEFAULT NULL,\n  `replicated_at` datetime DEFAULT NULL,\n  `extracted_at` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  KEY `index_on_extracted_at_and_id_and_replicated_at` (`extracted_at`,`id`,`replicated_at`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci"}:Hash
/Users/pedropb/.gem/ruby/3.2.2/gems/lhm-shopify-3.5.5/lib/lhm/table.rb:44:in `block in ddl'
/Users/pedropb/.gem/ruby/3.2.2/gems/activerecord-6.1.7.6/lib/active_record/result.rb:62:in `block in each'
/Users/pedropb/.gem/ruby/3.2.2/gems/activerecord-6.1.7.6/lib/active_record/result.rb:62:in `each'
```

![image](https://github.com/Shopify/lhm/assets/15254163/8fda10d6-2245-4384-9a54-ccceae8fbcfa)
