### PR TITLE
Handle composite primary keys with line breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# 4.2.3 (Jul, 2024)
+* Fix check for warnings against PKs with line breaks
+
 # 4.2.2 (Jun, 2024)
 * Avoid using the INSTANT algorithm.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lhm-shopify (4.2.2)
+    lhm-shopify (4.2.3)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_6.1.gemfile.lock
+++ b/gemfiles/activerecord_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (4.2.2)
+    lhm-shopify (4.2.3)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_7.0.gemfile.lock
+++ b/gemfiles/activerecord_7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (4.2.2)
+    lhm-shopify (4.2.3)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_7.1.gemfile.lock
+++ b/gemfiles/activerecord_7.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (4.2.2)
+    lhm-shopify (4.2.3)
       retriable (>= 3.0.0)
 
 GEM

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -23,7 +23,6 @@ module Lhm
       @chunk_finder = ChunkFinder.new(migration, connection, options)
       @options = options
       @raise_on_warnings = options.fetch(:raise_on_warnings, false)
-      @pk_duplicate_warning_regexp ||= /Duplicate entry .+ for key '(#{@migration.destination_name}\.)?PRIMARY'/
       @verifier = options[:verifier]
       if @throttler = options[:throttler]
         @throttler.connection = @connection if @throttler.respond_to?(:connection=)
@@ -81,7 +80,7 @@ module Lhm
 
     def raise_on_non_pk_duplicate_warning
       @connection.select_all("SHOW WARNINGS", should_retry: true, log_prefix: LOG_PREFIX).each do |row|
-        next if row["Message"].match?(@pk_duplicate_warning_regexp)
+        next if row["Message"].start_with?("Duplicate entry") && row["Message"].match?(/for key '(#{@migration.destination_name}\.)?PRIMARY'\z/)
 
         m = "Unexpected warning found for inserted row: #{row["Message"]}"
         Lhm.logger.warn(m)

--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = '4.2.2'
+  VERSION = '4.2.3'
 end

--- a/spec/fixtures/composite_primary_key_with_varchar_columns.ddl
+++ b/spec/fixtures/composite_primary_key_with_varchar_columns.ddl
@@ -1,0 +1,10 @@
+CREATE TABLE `composite_primary_key_with_varchar_columns` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `shop_id` bigint NOT NULL,
+  `owner_type` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `owner_id` bigint NOT NULL,
+  `namespace` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `key` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`shop_id`,`owner_type`,`owner_id`,`namespace`,`key`),
+  UNIQUE KEY `id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci ROW_FORMAT=DYNAMIC

--- a/spec/fixtures/composite_primary_key_with_varchar_columns_dest.ddl
+++ b/spec/fixtures/composite_primary_key_with_varchar_columns_dest.ddl
@@ -1,0 +1,10 @@
+CREATE TABLE `composite_primary_key_with_varchar_columns_dest` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `shop_id` bigint NOT NULL,
+  `owner_type` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `owner_id` bigint NOT NULL,
+  `namespace` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `key` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`shop_id`,`owner_type`,`owner_id`,`namespace`,`key`),
+  UNIQUE KEY `id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci ROW_FORMAT=DYNAMIC


### PR DESCRIPTION
We've encountered problems with composite primary keys, including varchar columns with values that have line breaks. The regex used to ignore primary key duplicate warnings can't handle the line breaks, which leads to LHM aborting completely safe migrations.

This PR rejiggers the warning matching to avoid this.