### PR TITLE
Update docker compose command to be V2 compatible:

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Setup MySQL and ProxySQL (docker-compose)
         # Might have to change to docker compose up -d (i.e. Compose V2) when the Ubuntu image changes the docker-compose version
-        run: docker-compose -f docker-compose-mysql-${{ matrix.mysql }}.yml up -d
+        run: docker compose -f docker-compose-mysql-${{ matrix.mysql }}.yml up -d
 
       - name: Wait until DBs are alive
         run: ./scripts/helpers/wait-for-dbs.sh


### PR DESCRIPTION
docker compose syntax seems to no longer be supported on gh actions job runners (ref: https://github.com/Shopify/lhm/actions/runs/10220827210/job/28282002356)

Replaced with docker compose