### PR TITLE
Add option to force tables to use default engine

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -54,9 +54,9 @@ module Lhm
   def change_table(table_name, options = {}, &block)
     with_flags(options) do
       origin = Table.parse(table_name, connection)
-      invoker = Invoker.new(origin, connection)
+      invoker = Invoker.new(origin, connection, options)
       block.call(invoker.migrator)
-      invoker.run(options)
+      invoker.run
       true
     end
   end

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -15,12 +15,13 @@ module Lhm
 
     attr_reader :name, :statements, :connection, :conditions, :renames, :origin
 
-    def initialize(table, connection = nil)
+    def initialize(table, connection = nil, options = {})
       @connection = connection
       @origin = table
       @name = table.destination_name
       @statements = []
       @renames = {}
+      @options = options
     end
 
     # Alter a table with a custom statement
@@ -222,6 +223,11 @@ module Lhm
       original    = %{CREATE TABLE `#{ @origin.name }`}
       replacement = %{CREATE TABLE `#{ @origin.destination_name }`}
       stmt = @origin.ddl.gsub(original, replacement)
+
+      if @options[:force_default_engine]
+        stmt = stmt.sub(/ENGINE=\w+\s/, "")
+      end
+
       @connection.execute(tagged(stmt))
 
       Lhm.logger.info("Created destination table #{@origin.destination_name}")

--- a/spec/fixtures/myisam_users.ddl
+++ b/spec/fixtures/myisam_users.ddl
@@ -1,0 +1,10 @@
+CREATE TABLE `myisam_users` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `reference` int(11) DEFAULT NULL,
+  `username` varchar(255) DEFAULT NULL,
+  `group` varchar(255) DEFAULT 'Superfriends',
+  `created_at` datetime DEFAULT NULL,
+  `comment` varchar(20) DEFAULT NULL,
+  `description` text,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM CHARSET=utf8


### PR DESCRIPTION
Adds a `force_default_engine` option. When enabled LHM will create the shadow table without copying the engine of the original table, meaning the migration will change the table to the default engine.