### PR TITLE
Change default algorithm for add/rename/remove column operations

### DIFF
--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -56,7 +56,7 @@ module Lhm
     # @param [String] name Name of the column to add
     # @param [String] definition Valid SQL column definition
     # @param [String] algorithm Algorithm that will be used in the DDL operation
-    def add_column(name, definition, algorithm: 'INPLACE')
+    def add_column(name, definition, algorithm: 'COPY')
       ddl('alter table `%s` add column `%s` %s' % [@name, name, definition], algorithm:)
     end
 
@@ -89,7 +89,7 @@ module Lhm
     # @param [String] old Name of the column to change
     # @param [String] nu New name to use for the column
     # @param [String] algorithm Algorithm that will be used in the DDL operation
-    def rename_column(old, nu, algorithm: 'INPLACE')
+    def rename_column(old, nu, algorithm: 'COPY')
       col = @origin.columns[old.to_s]
 
       definition = col[:type]
@@ -113,7 +113,7 @@ module Lhm
     #
     # @param [String] name Name of the column to delete
     # @param [String] algorithm Algorithm that will be used in the DDL operation
-    def remove_column(name, algorithm: 'INPLACE')
+    def remove_column(name, algorithm: 'COPY')
       ddl('alter table `%s` drop `%s`' % [@name, name], algorithm:)
     end
 

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -574,6 +574,18 @@ describe Lhm do
       value(engine).must_equal("InnoDB")
     end
 
+    it "should not fail using the default algorithms when changing tables with fulltext indexes" do
+      table_create(:users)
+      execute("DROP INDEX `index_with_a_custom_name` ON `users`")
+      execute("CREATE FULLTEXT INDEX `index_with_a_custom_name` ON `users` (`username`, `group`)")
+
+      Lhm.change_table(:users) do |t|
+        t.add_column(:email, "VARCHAR(255)")
+      end
+
+      value(table_read(:users).columns).must_include("email")
+    end
+
     describe 'parallel' do
       it 'should perserve inserts during migration' do
         50.times { |n| execute("insert into users set reference = '#{ n }'") }

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -97,7 +97,7 @@ describe Lhm::Migrator do
       @creator.add_column('logins', 'INT(12)')
 
       value(@creator.statements).must_equal([
-        'alter table `lhmn_alt` add column `logins` INT(12), ALGORITHM=INPLACE'
+        'alter table `lhmn_alt` add column `logins` INT(12), ALGORITHM=COPY'
       ])
     end
 
@@ -113,7 +113,7 @@ describe Lhm::Migrator do
       @creator.remove_column('logins')
 
       value(@creator.statements).must_equal([
-        'alter table `lhmn_alt` drop `logins`, ALGORITHM=INPLACE'
+        'alter table `lhmn_alt` drop `logins`, ALGORITHM=COPY'
       ])
     end
 
@@ -167,24 +167,24 @@ describe Lhm::Migrator do
       value(@creator.statements.length).must_equal(2)
 
       value(@creator.statements[0])
-        .must_equal('alter table `lhmn_alt` add column `first` VARCHAR(64), ALGORITHM=INPLACE')
+        .must_equal('alter table `lhmn_alt` add column `first` VARCHAR(64), ALGORITHM=COPY')
 
       value(@creator.statements[1])
-        .must_equal('alter table `lhmn_alt` add column `last` VARCHAR(64), ALGORITHM=INPLACE')
+        .must_equal('alter table `lhmn_alt` add column `last` VARCHAR(64), ALGORITHM=COPY')
     end
   end
 
   describe 'multiple changes using the passed algorithm' do
     it 'should add two columns' do
-      @creator.add_column('first', 'VARCHAR(64)', algorithm: 'COPY')
-      @creator.add_column('last', 'VARCHAR(64)', algorithm: 'COPY')
+      @creator.add_column('first', 'VARCHAR(64)', algorithm: 'INPLACE')
+      @creator.add_column('last', 'VARCHAR(64)', algorithm: 'INPLACE')
       value(@creator.statements.length).must_equal(2)
 
       value(@creator.statements[0])
-        .must_equal('alter table `lhmn_alt` add column `first` VARCHAR(64), ALGORITHM=COPY')
+        .must_equal('alter table `lhmn_alt` add column `first` VARCHAR(64), ALGORITHM=INPLACE')
 
       value(@creator.statements[1])
-        .must_equal('alter table `lhmn_alt` add column `last` VARCHAR(64), ALGORITHM=COPY')
+        .must_equal('alter table `lhmn_alt` add column `last` VARCHAR(64), ALGORITHM=INPLACE')
     end
   end
 end


### PR DESCRIPTION
Changes the default algorithm used for add/rename/remove column operations to `COPY` since it supports more use cases. It is slower, but that doesn't matter much since the changes are applied to empty tables.

Fixes #161.