### PR TITLE
Update dev.yml

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 name: lhm
 up:
   - packages:
-      - mysql-client@5.7
+      - mysql-client
       - wget
   - ruby
   - bundler
@@ -12,8 +12,9 @@ up:
       meet: ":"
   - custom:
       name: Podman compose
-      met?: podman-compose ps | grep -ioE -q "lhm.*running\(4\)"
-      meet: podman-compose up -d
+      met?: "[[ $(podman-compose ps | grep -c -e 'running' -e 'Up') == 4 ]] 2> /dev/null"
+      meet: podman-compose -f docker-compose-mysql-8.0.yml up -d
+      down: podman-compose down
   - custom:
       name: Waiting for DBs to be operational
       met?: ./scripts/helpers/wait-for-dbs.sh


### PR DESCRIPTION
Hopefully this makes sense for users of `dev`
- use mysql-client 8, the 5.7 is now [unsupported by homebrew](https://formulae.brew.sh/formula/mysql-client@5.7)
- switch to mysql 8 for dev setup, fix the podman build step

Note: I had to switch the `proxysql` service to linux/arm64 locally due to segfault on the podman VM. This change would break the CI. 
```
[proxysql]  | qemu: uncaught target signal 11 (Segmentation fault) - core dumped
```