### PR TITLE
Create update before insert trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+
+# 4.5.1 (Jul, 2025)
 * Create update before insert trigger
 
 # 4.5.0 (Feb, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* Create update before insert trigger
 
 # 4.5.0 (Feb, 2025)
 * Update test matrix to include Rails 8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lhm-shopify (4.5.0)
+    lhm-shopify (4.5.1)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_7.2.gemfile.lock
+++ b/gemfiles/activerecord_7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (4.5.0)
+    lhm-shopify (4.5.1)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_8.0.gemfile.lock
+++ b/gemfiles/activerecord_8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (4.5.0)
+    lhm-shopify (4.5.1)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_head.gemfile.lock
+++ b/gemfiles/activerecord_head.gemfile.lock
@@ -26,7 +26,7 @@ GIT
 PATH
   remote: ..
   specs:
-    lhm-shopify (4.5.0)
+    lhm-shopify (4.5.1)
       retriable (>= 3.0.0)
 
 GEM

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -27,8 +27,8 @@ module Lhm
     def entangle
       [
         create_delete_trigger,
+        create_update_trigger,
         create_insert_trigger,
-        create_update_trigger
       ]
     end
 

--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = '4.5.0'
+  VERSION = '4.5.1'
 end


### PR DESCRIPTION
Changes the order we create triggers in to prevent the following scenario:

1. LHM creates shadow table.
2. LHM creates delete trigger.
3. LHM creates insert trigger.
4. Rows are inserted into the table and immediately updated.
5. LHM creates update trigger.
6. LHM copies over all rows.
7. LHM validates triggers, does the cutover, deletes the triggers, and is done.

Result: The inserts were replicated to the shadow table via the insert trigger, but the updates were not. Copying those rows failed since they already existed in the shadow table, and LHM ignored the error. We now have stale data after the migration finishes.

We ensure this can't happen by creating the update trigger first.