### PR TITLE
Use concrete Trilogy retry exception classes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,12 @@ jobs:
             ruby: head
           - activerecord: 8.0
             ruby: 3.1
+          - activerecord: 8.0
+            ruby: head
           - activerecord: head
             ruby: 3.1
+          - activerecord: head
+            ruby: head
 
     env:
       BUNDLE_GEMFILE: "${{ github.workspace }}/gemfiles/activerecord_${{ matrix.activerecord }}.gemfile"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 4.5.2 (Jun, 2026)
 * Use concrete Trilogy connection exception classes in retry configuration.
-* Use a retriable-compatible unbounded max elapsed time value.
+* Use a retriable-compatible effectively unbounded max elapsed time value.
 
 # 4.5.1 (Jul, 2025)
 * Create update before insert trigger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+
+# 4.5.2 (Jun, 2026)
 * Use concrete Trilogy connection exception classes in retry configuration.
 
 # 4.5.1 (Jul, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 4.5.2 (Jun, 2026)
 * Use concrete Trilogy connection exception classes in retry configuration.
+* Use a retriable-compatible unbounded max elapsed time value.
 
 # 4.5.1 (Jul, 2025)
 * Create update before insert trigger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* Use concrete Trilogy connection exception classes in retry configuration.
 
 # 4.5.1 (Jul, 2025)
 * Create update before insert trigger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lhm-shopify (4.5.1)
+    lhm-shopify (4.5.2)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_7.2.gemfile.lock
+++ b/gemfiles/activerecord_7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (4.5.1)
+    lhm-shopify (4.5.2)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_8.0.gemfile.lock
+++ b/gemfiles/activerecord_8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lhm-shopify (4.5.1)
+    lhm-shopify (4.5.2)
       retriable (>= 3.0.0)
 
 GEM

--- a/gemfiles/activerecord_head.gemfile.lock
+++ b/gemfiles/activerecord_head.gemfile.lock
@@ -26,7 +26,7 @@ GIT
 PATH
   remote: ..
   specs:
-    lhm-shopify (4.5.1)
+    lhm-shopify (4.5.2)
       retriable (>= 3.0.0)
 
 GEM

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -65,7 +65,11 @@ module Lhm
     end
 
     def triggers_still_exist?(conn, entangler)
-      triggers = conn.select_values("SHOW TRIGGERS LIKE '%#{migrator.origin.name}'").select { |name| name =~ /^lhmt/ }
+      triggers = conn.select_values(
+        "SHOW TRIGGERS LIKE '%#{migrator.origin.name}'",
+        should_retry: true,
+        log_prefix: "Invoker"
+      ).select { |name| name =~ /^lhmt/ }
       triggers.sort == entangler.expected_triggers.sort
     end
 

--- a/lib/lhm/sql_retry.rb
+++ b/lib/lhm/sql_retry.rb
@@ -158,7 +158,7 @@ module Lhm
         base_interval: 1, # the initial interval in seconds between tries.
         tries: 20, # Number of attempts to make at running your code block (includes initial attempt).
         rand_factor: 0, # percentage to randomize the next retry interval time
-        max_elapsed_time: nil, # max total time in seconds that code is allowed to keep being retried
+        max_elapsed_time: Float::MAX, # max total time in seconds that code is allowed to keep being retried
         on_retry: Proc.new do |exception, try_number, total_elapsed_time, next_interval|
           log_with_prefix("#{exception.class}: '#{exception.message}' - #{try_number} tries in #{total_elapsed_time} seconds and #{next_interval} seconds until the next try.", :error)
         end

--- a/lib/lhm/sql_retry.rb
+++ b/lib/lhm/sql_retry.rb
@@ -158,7 +158,7 @@ module Lhm
         base_interval: 1, # the initial interval in seconds between tries.
         tries: 20, # Number of attempts to make at running your code block (includes initial attempt).
         rand_factor: 0, # percentage to randomize the next retry interval time
-        max_elapsed_time: Float::INFINITY, # max total time in seconds that code is allowed to keep being retried
+        max_elapsed_time: nil, # max total time in seconds that code is allowed to keep being retried
         on_retry: Proc.new do |exception, try_number, total_elapsed_time, next_interval|
           log_with_prefix("#{exception.class}: '#{exception.message}' - #{try_number} tries in #{total_elapsed_time} seconds and #{next_interval} seconds until the next try.", :error)
         end

--- a/lib/lhm/sql_retry.rb
+++ b/lib/lhm/sql_retry.rb
@@ -198,15 +198,27 @@ module Lhm
           /connection is locked to hostgroup/,
           /The MySQL server is running with the --read-only option so it cannot execute this statement/,
         ],
-        Trilogy::ConnectionError => nil,
-        Trilogy::TimeoutError => nil,
       }
+
+      retriable_trilogy_connection_error_classes.each do |error_class|
+        errors[error_class] = nil
+      end
 
       if ActiveRecord::VERSION::STRING >= "7.1"
         errors[ActiveRecord::ConnectionFailed] = nil
       end
 
       errors
+    end
+
+    def retriable_trilogy_connection_error_classes
+      errors = []
+      errors << Trilogy::BaseConnectionError if defined?(Trilogy::BaseConnectionError)
+      errors << Trilogy::SSLError if defined?(Trilogy::SSLError)
+      errors << Trilogy::ConnectionClosed if defined?(Trilogy::ConnectionClosed)
+      errors.concat(Trilogy::SyscallError::ERRORS.values) if defined?(Trilogy::SyscallError::ERRORS)
+
+      errors.uniq.select { |error_class| error_class.is_a?(Class) && error_class <= Exception }
     end
   end
 end

--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = '4.5.1'
+  VERSION = '4.5.2'
 end

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -646,11 +646,13 @@ describe Lhm do
         50.times { |n| execute("insert into users set reference = '#{ n }'") }
 
         insert = Thread.new do
+          connection = new_mysql_connection
           10.times do |n|
-            connect_master!
-            execute("insert into users set reference = '#{ 100 + n }'")
+            connection.query("insert into users set reference = '#{ 100 + n }'")
             sleep(0.17)
           end
+        ensure
+          connection&.close
         end
         sleep 2
 
@@ -670,10 +672,13 @@ describe Lhm do
         50.times { |n| execute("insert into users set reference = '#{ n }'") }
 
         delete = Thread.new do
+          connection = new_mysql_connection
           10.times do |n|
-            execute("delete from users where reference = '#{ n }'")
+            connection.query("delete from users where reference = '#{ n }'")
             sleep(0.17)
           end
+        ensure
+          connection&.close
         end
         sleep 2
 

--- a/spec/unit/sql_retry_spec.rb
+++ b/spec/unit/sql_retry_spec.rb
@@ -1,0 +1,27 @@
+require 'minitest/autorun'
+require 'minitest/spec'
+require 'active_record'
+require 'lhm/sql_retry'
+require 'trilogy'
+
+describe Lhm::SqlRetry do
+  describe '#retriable_trilogy_errors' do
+    it 'only uses exception classes as retriable keys' do
+      retry_errors = Lhm::SqlRetry.new(nil).send(:retriable_trilogy_errors)
+
+      retry_errors.each_key do |error_class|
+        assert error_class.is_a?(Class), "#{error_class.inspect} is not a class"
+        assert error_class <= Exception, "#{error_class.inspect} is not an exception class"
+      end
+    end
+
+    it 'matches trilogy connection error classes without using the ConnectionError module' do
+      retry_errors = Lhm::SqlRetry.new(nil).send(:retriable_trilogy_errors)
+
+      refute_includes retry_errors.keys, Trilogy::ConnectionError
+      assert_includes retry_errors.keys, Trilogy::BaseConnectionError
+      assert_includes retry_errors.keys, Trilogy::ConnectionClosed
+      assert_includes retry_errors.keys, Trilogy::SSLError
+    end
+  end
+end

--- a/spec/unit/sql_retry_spec.rb
+++ b/spec/unit/sql_retry_spec.rb
@@ -5,6 +5,14 @@ require 'lhm/sql_retry'
 require 'trilogy'
 
 describe Lhm::SqlRetry do
+  describe '#default_retry_config' do
+    it 'uses an unbounded max elapsed time value compatible with retriable validation' do
+      retry_config = Lhm::SqlRetry.new(nil).send(:default_retry_config)
+
+      assert_nil retry_config[:max_elapsed_time]
+    end
+  end
+
   describe '#retriable_trilogy_errors' do
     it 'only uses exception classes as retriable keys' do
       retry_errors = Lhm::SqlRetry.new(nil).send(:retriable_trilogy_errors)

--- a/spec/unit/sql_retry_spec.rb
+++ b/spec/unit/sql_retry_spec.rb
@@ -6,10 +6,10 @@ require 'trilogy'
 
 describe Lhm::SqlRetry do
   describe '#default_retry_config' do
-    it 'uses an unbounded max elapsed time value compatible with retriable validation' do
+    it 'uses an effectively unbounded max elapsed time value compatible with retriable validation' do
       retry_config = Lhm::SqlRetry.new(nil).send(:default_retry_config)
 
-      assert_nil retry_config[:max_elapsed_time]
+      assert_equal Float::MAX, retry_config[:max_elapsed_time]
     end
   end
 


### PR DESCRIPTION
## Summary
- Replace the `Trilogy::ConnectionError` retry key with concrete Trilogy connection exception classes.
- Filter Trilogy retry keys to actual `Exception` classes so newer `retriable` versions accept the config.
- Use `max_elapsed_time: Float::MAX` instead of `Float::INFINITY` for an effectively unbounded elapsed time in a format accepted by both older and newer `retriable`.
- Retry trigger existence checks during LHM invocations.
- Update parallel integration tests to use separate writer connections.
- Bump `lhm-shopify` to `4.5.2`.

## Why
Newer `retriable` versions validate the `on:` configuration before running the retried block. Each retry key must be an exception class, or a collection of exception classes.

`Trilogy::ConnectionError` is a module, not an exception class, and `max_elapsed_time: Float::INFINITY` is no longer accepted by newer `retriable` as a finite non-negative number. LHM can fail during retry configuration validation with errors like:

```
on must be an Exception class or a collection of Exception classes, got Trilogy::ConnectionError
max_elapsed_time must be a non-negative number
```

This changes the Trilogy retry config to use concrete exception classes such as `Trilogy::BaseConnectionError`, `Trilogy::SSLError`, `Trilogy::ConnectionClosed`, and the concrete syscall error classes, preserving the intended retry behavior while remaining compatible with stricter `retriable` validation.

## Release
This PR bumps the gem version to `4.5.2` and updates the changelog/lockfiles. After merge, a maintainer can publish with:

```sh
bundle exec rake release
```

## Test
- `bundle install`
- `bundle exec appraisal install`
- `bundle exec ruby -I spec spec/unit/sql_retry_spec.rb`
- `bundle exec rake build`

